### PR TITLE
fix inv of 2

### DIFF
--- a/arith/src/extension_field/m31_ext.rs
+++ b/arith/src/extension_field/m31_ext.rs
@@ -63,14 +63,17 @@ impl Field for M31Ext3 {
         v: [M31::ZERO, M31::ZERO, M31::ZERO],
     };
 
-    const INV_2: M31Ext3 = M31Ext3 {
-        v: [M31::INV_2, M31 { v: 0 }, M31 { v: 0 }],
-    };
-
     #[inline(always)]
     fn zero() -> Self {
         M31Ext3 {
             v: [M31 { v: 0 }; 3],
+        }
+    }
+
+    #[inline(always)]
+    fn inv_of_2() -> Self {
+        Self {
+            v: [M31::inv_of_2(), M31 { v: 0 }, M31 { v: 0 }],
         }
     }
 

--- a/arith/src/extension_field/simd_m31_ext.rs
+++ b/arith/src/extension_field/simd_m31_ext.rs
@@ -129,14 +129,17 @@ impl Field for SimdM31Ext3 {
         v: [SimdM31::ZERO; 3],
     };
 
-    const INV_2: Self = Self {
-        v: [SimdM31::INV_2, SimdM31::ZERO, SimdM31::ZERO],
-    };
-
     #[inline(always)]
     fn zero() -> Self {
         SimdM31Ext3 {
             v: [SimdM31::zero(); 3],
+        }
+    }
+
+    #[inline(always)]
+    fn inv_of_2() -> Self {
+        Self {
+            v: [SimdM31::inv_of_2(), SimdM31::zero(), SimdM31::zero()],
         }
     }
 

--- a/arith/src/field.rs
+++ b/arith/src/field.rs
@@ -46,9 +46,6 @@ pub trait Field:
     /// zero
     const ZERO: Self;
 
-    /// Inverse of 2
-    const INV_2: Self;
-
     // ====================================
     // constants
     // ====================================
@@ -60,6 +57,11 @@ pub trait Field:
 
     /// Identity element
     fn one() -> Self;
+
+    /// Inverse of 2, may not exist
+    fn inv_of_2() -> Self {
+        unimplemented!("inv of 2 does not exist")
+    }
 
     // ====================================
     // generators

--- a/arith/src/field/bn254.rs
+++ b/arith/src/field/bn254.rs
@@ -16,9 +16,6 @@ impl Field for Fr {
     /// zero
     const ZERO: Self = Fr::zero();
 
-    /// Inverse of 2
-    const INV_2: Self = Fr::TWO_INV;
-
     // ====================================
     // constants
     // ====================================
@@ -37,6 +34,11 @@ impl Field for Fr {
     #[inline(always)]
     fn one() -> Self {
         Fr::one()
+    }
+
+    #[inline(always)]
+    fn inv_of_2() -> Self {
+        Fr::TWO_INV
     }
 
     // ====================================

--- a/arith/src/field/m31.rs
+++ b/arith/src/field/m31.rs
@@ -90,8 +90,6 @@ impl Field for M31 {
 
     const ZERO: Self = M31 { v: 0 };
 
-    const INV_2: M31 = M31 { v: 1 << 30 };
-
     #[inline(always)]
     fn zero() -> Self {
         M31 { v: 0 }
@@ -100,6 +98,11 @@ impl Field for M31 {
     #[inline(always)]
     fn one() -> Self {
         M31 { v: 1 }
+    }
+
+    #[inline(always)]
+    fn inv_of_2() -> Self {
+        M31 { v: 1 << 30 }
     }
 
     #[inline(always)]

--- a/arith/src/field/m31/m31_avx.rs
+++ b/arith/src/field/m31/m31_avx.rs
@@ -89,9 +89,7 @@ impl Field for AVXM31 {
 
     #[inline(always)]
     fn inv_of_2() -> Self {
-        Self {
-            v: [PACKED_INV_2; 2],
-        }
+        Self { v: PACKED_INV_2 }
     }
 
     #[inline(always)]

--- a/arith/src/field/m31/m31_avx.rs
+++ b/arith/src/field/m31/m31_avx.rs
@@ -80,12 +80,17 @@ impl Field for AVXM31 {
 
     const ZERO: Self = Self { v: PACKED_0 };
 
-    const INV_2: Self = Self { v: PACKED_INV_2 };
-
     #[inline(always)]
     fn zero() -> Self {
         AVXM31 {
             v: unsafe { _mm512_set1_epi32(0) },
+        }
+    }
+
+    #[inline(always)]
+    fn inv_of_2() -> Self {
+        Self {
+            v: [PACKED_INV_2; 2],
         }
     }
 

--- a/arith/src/field/m31/m31_neon.rs
+++ b/arith/src/field/m31/m31_neon.rs
@@ -83,13 +83,16 @@ impl Field for NeonM31 {
         v: [PACKED_0, PACKED_0],
     };
 
-    const INV_2: Self = Self {
-        v: [PACKED_INV_2; 2],
-    };
-
     #[inline(always)]
     fn zero() -> Self {
         Self { v: [PACKED_0; 2] }
+    }
+
+    #[inline(always)]
+    fn inv_of_2() -> Self {
+        Self {
+            v: [PACKED_INV_2; 2],
+        }
     }
 
     #[inline(always)]

--- a/src/prover/sumcheck_square_helper.rs
+++ b/src/prover/sumcheck_square_helper.rs
@@ -23,7 +23,7 @@ impl<const D: usize> SumcheckMultiSquareHelper<D> {
         let p_add_coef_0 = p_add[0];
         let p_add_coef_2 = C::field_mul_circuit_field(
             &(p_add[2] - p_add[1] - p_add[1] + p_add[0]),
-            &C::CircuitField::INV_2,
+            &C::CircuitField::inv_of_2(),
         );
 
         let p_add_coef_1 = p_add[1] - p_add_coef_0 - p_add_coef_2;

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -14,7 +14,7 @@ use crate::{
 #[inline]
 fn degree_2_eval<F: Field + SimdField>(p0: F, p1: F, p2: F, x: F::Scalar) -> F {
     let c0 = &p0;
-    let c2 = F::INV_2 * (p2 - p1 - p1 + p0);
+    let c2 = F::inv_of_2() * (p2 - p1 - p1 + p0);
     let c1 = p1 - p0 - c2;
     *c0 + (c2.scale(&x) + c1).scale(&x)
 }


### PR DESCRIPTION
- use a function call instead of a constant
- default implementation is unimplemented so `F_{2^m}` doesn't need to implement `inv_of_2`