### PR TITLE
Minor: Serialization and Deserialization Error Propagation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ sha2 = "0.10.8"
 tokio = { version = "1.38.0", features = ["full"] }
 tynm = { version = "0.1.6", default-features = false }
 warp = "0.3.7"
+zerocopy = "0.7.35"
+zerocopy-derive = "0.7.35"
 
 [[bench]]
 name = "arith"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,6 @@ sha2 = "0.10.8"
 tokio = { version = "1.38.0", features = ["full"] }
 tynm = { version = "0.1.6", default-features = false }
 warp = "0.3.7"
-zerocopy = "0.7.35"
-zerocopy-derive = "0.7.35"
 
 [[bench]]
 name = "arith"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ log.workspace = true
 rand.workspace = true
 sha2.workspace = true
 halo2curves.workspace = true
+thiserror.workspace = true
 
 # for the server
 bytes.workspace = true
@@ -57,6 +58,7 @@ sha2 = "0.10.8"
 tokio = { version = "1.38.0", features = ["full"] }
 tynm = { version = "0.1.6", default-features = false }
 warp = "0.3.7"
+thiserror = "1.0.63"
 
 [[bench]]
 name = "arith"

--- a/arith/Cargo.toml
+++ b/arith/Cargo.toml
@@ -9,6 +9,7 @@ halo2curves.workspace = true
 log.workspace = true
 rand.workspace = true
 sha2.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 tynm.workspace = true

--- a/arith/Cargo.toml
+++ b/arith/Cargo.toml
@@ -9,8 +9,6 @@ halo2curves.workspace = true
 log.workspace = true
 rand.workspace = true
 sha2.workspace = true
-zerocopy.workspace = true
-zerocopy-derive.workspace = true
 
 [dev-dependencies]
 tynm.workspace = true

--- a/arith/Cargo.toml
+++ b/arith/Cargo.toml
@@ -9,6 +9,8 @@ halo2curves.workspace = true
 log.workspace = true
 rand.workspace = true
 sha2.workspace = true
+zerocopy.workspace = true
+zerocopy-derive.workspace = true
 
 [dev-dependencies]
 tynm.workspace = true

--- a/arith/src/extension_field/gf2_128/avx.rs
+++ b/arith/src/extension_field/gf2_128/avx.rs
@@ -43,10 +43,7 @@ impl FieldSerde for AVX512GF2_128 {
     #[inline(always)]
     fn try_deserialize_from_ecc_format<R: std::io::Read>(
         mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error>
-    where
-        Self: Sized,
-    {
+    ) -> std::result::Result<Self, std::io::Error> {
         let mut u = [0u8; 32];
         reader.read_exact(&mut u)?;
         Ok(unsafe {

--- a/arith/src/extension_field/gf2_128/avx.rs
+++ b/arith/src/extension_field/gf2_128/avx.rs
@@ -25,11 +25,11 @@ impl FieldSerde for AVX512GF2_128 {
 
     #[inline(always)]
     fn deserialize_from<R: std::io::Read>(mut reader: R) -> FieldSerdeResult<Self> {
-        let mut u = [0u8; 16];
+        let mut u = [0u8; Self::SERIALIZED_SIZE];
         reader.read_exact(&mut u)?;
         unsafe {
             Ok(AVX512GF2_128 {
-                v: transmute::<[u8; 16], __m128i>(u),
+                v: transmute::<[u8; Self::SERIALIZED_SIZE], __m128i>(u),
             })
         }
     }

--- a/arith/src/extension_field/gf2_128/avx.rs
+++ b/arith/src/extension_field/gf2_128/avx.rs
@@ -15,15 +15,12 @@ pub struct AVX512GF2_128 {
 field_common!(AVX512GF2_128);
 
 impl FieldSerde for AVX512GF2_128 {
+    const SERIALIZED_SIZE: usize = 16;
+
     #[inline(always)]
     fn serialize_into<W: std::io::Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         unsafe { writer.write_all(transmute::<__m128i, [u8; 16]>(self.v).as_ref())? };
         Ok(())
-    }
-
-    #[inline(always)]
-    fn serialized_size() -> usize {
-        16
     }
 
     #[inline(always)]

--- a/arith/src/extension_field/gf2_128/avx.rs
+++ b/arith/src/extension_field/gf2_128/avx.rs
@@ -16,12 +16,11 @@ field_common!(AVX512GF2_128);
 
 impl FieldSerde for AVX512GF2_128 {
     #[inline(always)]
-    fn serialize_into<W: std::io::Write>(&self, mut writer: W) {
-        unsafe {
-            writer
-                .write_all(transmute::<__m128i, [u8; 16]>(self.v).as_ref())
-                .unwrap(); // todo: error propagation
-        }
+    fn serialize_into<W: std::io::Write>(
+        &self,
+        mut writer: W,
+    ) -> std::result::Result<(), std::io::Error> {
+        unsafe { writer.write_all(transmute::<__m128i, [u8; 16]>(self.v).as_ref()) }
     }
 
     #[inline(always)]

--- a/arith/src/extension_field/gf2_128/avx.rs
+++ b/arith/src/extension_field/gf2_128/avx.rs
@@ -5,7 +5,7 @@ use std::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-use crate::{field_common, BinomialExtensionField, Field, FieldSerde, GF2};
+use crate::{field_common, BinomialExtensionField, Field, FieldSerde, FieldSerdeResult, GF2};
 
 #[derive(Debug, Clone, Copy)]
 pub struct AVX512GF2_128 {
@@ -16,11 +16,9 @@ field_common!(AVX512GF2_128);
 
 impl FieldSerde for AVX512GF2_128 {
     #[inline(always)]
-    fn serialize_into<W: std::io::Write>(
-        &self,
-        mut writer: W,
-    ) -> std::result::Result<(), std::io::Error> {
-        unsafe { writer.write_all(transmute::<__m128i, [u8; 16]>(self.v).as_ref()) }
+    fn serialize_into<W: std::io::Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
+        unsafe { writer.write_all(transmute::<__m128i, [u8; 16]>(self.v).as_ref())? };
+        Ok(())
     }
 
     #[inline(always)]
@@ -29,9 +27,7 @@ impl FieldSerde for AVX512GF2_128 {
     }
 
     #[inline(always)]
-    fn deserialize_from<R: std::io::Read>(
-        mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error> {
+    fn deserialize_from<R: std::io::Read>(mut reader: R) -> FieldSerdeResult<Self> {
         let mut u = [0u8; 16];
         reader.read_exact(&mut u)?;
         unsafe {
@@ -42,9 +38,7 @@ impl FieldSerde for AVX512GF2_128 {
     }
 
     #[inline(always)]
-    fn try_deserialize_from_ecc_format<R: std::io::Read>(
-        mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error> {
+    fn try_deserialize_from_ecc_format<R: std::io::Read>(mut reader: R) -> FieldSerdeResult<Self> {
         let mut u = [0u8; 32];
         reader.read_exact(&mut u)?;
         Ok(unsafe {

--- a/arith/src/extension_field/gf2_128/avx.rs
+++ b/arith/src/extension_field/gf2_128/avx.rs
@@ -29,13 +29,15 @@ impl FieldSerde for AVX512GF2_128 {
     }
 
     #[inline(always)]
-    fn deserialize_from<R: std::io::Read>(mut reader: R) -> Self {
+    fn deserialize_from<R: std::io::Read>(
+        mut reader: R,
+    ) -> std::result::Result<Self, std::io::Error> {
         let mut u = [0u8; 16];
-        reader.read_exact(&mut u).unwrap(); // todo: error propagation
+        reader.read_exact(&mut u)?;
         unsafe {
-            AVX512GF2_128 {
+            Ok(AVX512GF2_128 {
                 v: transmute::<[u8; 16], __m128i>(u),
-            }
+            })
         }
     }
 

--- a/arith/src/extension_field/gf2_128/neon.rs
+++ b/arith/src/extension_field/gf2_128/neon.rs
@@ -45,13 +45,15 @@ impl FieldSerde for NeonGF2_128 {
     }
 
     #[inline(always)]
-    fn deserialize_from<R: std::io::Read>(mut reader: R) -> Self {
+    fn deserialize_from<R: std::io::Read>(
+        mut reader: R,
+    ) -> std::result::Result<Self, std::io::Error> {
         let mut u = [0u8; 16];
-        reader.read_exact(&mut u).unwrap(); // todo: error propagation
+        reader.read_exact(&mut u)?;
         unsafe {
-            NeonGF2_128 {
+            Ok(NeonGF2_128 {
                 v: transmute::<[u8; 16], uint32x4_t>(u),
-            }
+            })
         }
     }
 

--- a/arith/src/extension_field/gf2_128/neon.rs
+++ b/arith/src/extension_field/gf2_128/neon.rs
@@ -31,15 +31,12 @@ fn sub_internal(a: &NeonGF2_128, b: &NeonGF2_128) -> NeonGF2_128 {
 }
 
 impl FieldSerde for NeonGF2_128 {
+    const SERIALIZED_SIZE: usize = 16;
+
     #[inline(always)]
     fn serialize_into<W: std::io::Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         unsafe { writer.write_all(transmute::<uint32x4_t, [u8; 16]>(self.v).as_ref())? };
         Ok(())
-    }
-
-    #[inline(always)]
-    fn serialized_size() -> usize {
-        16
     }
 
     #[inline(always)]

--- a/arith/src/extension_field/gf2_128/neon.rs
+++ b/arith/src/extension_field/gf2_128/neon.rs
@@ -32,12 +32,11 @@ fn sub_internal(a: &NeonGF2_128, b: &NeonGF2_128) -> NeonGF2_128 {
 
 impl FieldSerde for NeonGF2_128 {
     #[inline(always)]
-    fn serialize_into<W: std::io::Write>(&self, mut writer: W) {
-        unsafe {
-            writer
-                .write_all(transmute::<uint32x4_t, [u8; 16]>(self.v).as_ref())
-                .unwrap(); // todo: error propagation
-        }
+    fn serialize_into<W: std::io::Write>(
+        &self,
+        mut writer: W,
+    ) -> std::result::Result<(), std::io::Error> {
+        unsafe { writer.write_all(transmute::<uint32x4_t, [u8; 16]>(self.v).as_ref()) }
     }
 
     #[inline(always)]

--- a/arith/src/extension_field/gf2_128x4/avx.rs
+++ b/arith/src/extension_field/gf2_128x4/avx.rs
@@ -24,6 +24,8 @@ impl AVX512GF2_128x4 {
 }
 
 impl FieldSerde for AVX512GF2_128x4 {
+    const SERIALIZED_SIZE: usize = 512 / 8;
+
     #[inline(always)]
     fn serialize_into<W: std::io::Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         unsafe {
@@ -32,10 +34,6 @@ impl FieldSerde for AVX512GF2_128x4 {
             writer.write_all(&data)?;
         }
         Ok(())
-    }
-    #[inline(always)]
-    fn serialized_size() -> usize {
-        512 / 8
     }
     #[inline(always)]
     fn deserialize_from<R: std::io::Read>(mut reader: R) -> FieldSerdeResult<Self> {

--- a/arith/src/extension_field/gf2_128x4/avx.rs
+++ b/arith/src/extension_field/gf2_128x4/avx.rs
@@ -37,7 +37,7 @@ impl FieldSerde for AVX512GF2_128x4 {
     }
     #[inline(always)]
     fn deserialize_from<R: std::io::Read>(mut reader: R) -> FieldSerdeResult<Self> {
-        let mut data = [0u8; 64];
+        let mut data = [0u8; Self::SERIALIZED_SIZE];
         reader.read_exact(&mut data)?;
         unsafe {
             Ok(Self {

--- a/arith/src/extension_field/gf2_128x4/avx.rs
+++ b/arith/src/extension_field/gf2_128x4/avx.rs
@@ -25,11 +25,14 @@ impl AVX512GF2_128x4 {
 
 impl FieldSerde for AVX512GF2_128x4 {
     #[inline(always)]
-    fn serialize_into<W: std::io::Write>(&self, mut writer: W) {
+    fn serialize_into<W: std::io::Write>(
+        &self,
+        mut writer: W,
+    ) -> std::result::Result<(), std::io::Error> {
         unsafe {
             let mut data = [0u8; 64];
             _mm512_storeu_si512(data.as_mut_ptr() as *mut i32, self.data);
-            writer.write_all(&data).unwrap();
+            writer.write_all(&data)
         }
     }
     #[inline(always)]

--- a/arith/src/extension_field/gf2_128x4/avx.rs
+++ b/arith/src/extension_field/gf2_128x4/avx.rs
@@ -40,13 +40,15 @@ impl FieldSerde for AVX512GF2_128x4 {
         512 / 8
     }
     #[inline(always)]
-    fn deserialize_from<R: std::io::Read>(mut reader: R) -> Self {
+    fn deserialize_from<R: std::io::Read>(
+        mut reader: R,
+    ) -> std::result::Result<Self, std::io::Error> {
         let mut data = [0u8; 64];
-        reader.read_exact(&mut data).unwrap();
+        reader.read_exact(&mut data)?;
         unsafe {
-            Self {
+            Ok(Self {
                 data: _mm512_loadu_si512(data.as_ptr() as *const i32),
-            }
+            })
         }
     }
 

--- a/arith/src/extension_field/gf2_128x4/avx.rs
+++ b/arith/src/extension_field/gf2_128x4/avx.rs
@@ -50,10 +50,7 @@ impl FieldSerde for AVX512GF2_128x4 {
     #[inline(always)]
     fn try_deserialize_from_ecc_format<R: std::io::Read>(
         mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error>
-    where
-        Self: Sized,
-    {
+    ) -> std::result::Result<Self, std::io::Error> {
         let mut buf = [0u8; 32];
         reader.read_exact(&mut buf)?;
         let data: __m128i = unsafe { _mm_loadu_si128(buf.as_ptr() as *const __m128i) };

--- a/arith/src/extension_field/gf2_128x4/neon.rs
+++ b/arith/src/extension_field/gf2_128x4/neon.rs
@@ -7,7 +7,7 @@ use crate::SimdField;
 use crate::{
     field_common,
     neon::{gfadd, gfmul, NeonGF2_128},
-    Field, FieldSerde,
+    Field, FieldSerde, FieldSerdeResult,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -33,10 +33,7 @@ impl PartialEq for NeonGF2_128x4 {
 
 impl FieldSerde for NeonGF2_128x4 {
     #[inline(always)]
-    fn serialize_into<W: std::io::Write>(
-        &self,
-        mut writer: W,
-    ) -> std::result::Result<(), std::io::Error> {
+    fn serialize_into<W: std::io::Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         self.v.iter().try_for_each(|&vv| {
             writer.write_all(unsafe { transmute::<uint32x4_t, [u8; 16]>(vv) }.as_ref())
         })
@@ -48,9 +45,7 @@ impl FieldSerde for NeonGF2_128x4 {
     }
 
     #[inline(always)]
-    fn deserialize_from<R: std::io::Read>(
-        mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error> {
+    fn deserialize_from<R: std::io::Read>(mut reader: R) -> FieldSerdeResult<Self> {
         let mut res = Self::zero();
         res.v.iter_mut().try_for_each(|vv| {
             let mut u = [0u8; 16];
@@ -61,12 +56,7 @@ impl FieldSerde for NeonGF2_128x4 {
     }
 
     #[inline]
-    fn try_deserialize_from_ecc_format<R: std::io::Read>(
-        mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error>
-    where
-        Self: Sized,
-    {
+    fn try_deserialize_from_ecc_format<R: std::io::Read>(mut reader: R) -> FieldSerdeResult<Self> {
         let mut res = Self::zero();
         res.v.iter_mut().for_each(|vv| {
             let mut u = [0u8; 32];

--- a/arith/src/extension_field/gf2_128x4/neon.rs
+++ b/arith/src/extension_field/gf2_128x4/neon.rs
@@ -33,11 +33,12 @@ impl PartialEq for NeonGF2_128x4 {
 
 impl FieldSerde for NeonGF2_128x4 {
     #[inline(always)]
-    fn serialize_into<W: std::io::Write>(&self, mut writer: W) {
-        self.v.iter().for_each(|&vv| {
-            writer
-                .write_all(unsafe { transmute::<uint32x4_t, [u8; 16]>(vv) }.as_ref())
-                .unwrap()
+    fn serialize_into<W: std::io::Write>(
+        &self,
+        mut writer: W,
+    ) -> std::result::Result<(), std::io::Error> {
+        self.v.iter().try_for_each(|&vv| {
+            writer.write_all(unsafe { transmute::<uint32x4_t, [u8; 16]>(vv) }.as_ref())
         })
     }
 

--- a/arith/src/extension_field/gf2_128x4/neon.rs
+++ b/arith/src/extension_field/gf2_128x4/neon.rs
@@ -49,7 +49,7 @@ impl FieldSerde for NeonGF2_128x4 {
             let mut u = [0u8; 16];
             reader.read_exact(&mut u)?;
             *vv = unsafe { transmute::<[u8; 16], uint32x4_t>(u) };
-            Ok::<(), std::io::Error>(())
+            Ok::<_, std::io::Error>(())
         })?;
         Ok(res)
     }
@@ -61,7 +61,7 @@ impl FieldSerde for NeonGF2_128x4 {
             let mut u = [0u8; 32];
             reader.read_exact(&mut u)?;
             *vv = unsafe { transmute::<[u8; 16], uint32x4_t>(u[..16].try_into().unwrap()) };
-            Ok::<(), std::io::Error>(())
+            Ok::<_, std::io::Error>(())
         })?;
         Ok(res)
     }

--- a/arith/src/extension_field/gf2_128x4/neon.rs
+++ b/arith/src/extension_field/gf2_128x4/neon.rs
@@ -48,14 +48,16 @@ impl FieldSerde for NeonGF2_128x4 {
     }
 
     #[inline(always)]
-    fn deserialize_from<R: std::io::Read>(mut reader: R) -> Self {
+    fn deserialize_from<R: std::io::Read>(
+        mut reader: R,
+    ) -> std::result::Result<Self, std::io::Error> {
         let mut res = Self::zero();
-        res.v.iter_mut().for_each(|vv| {
+        res.v.iter_mut().try_for_each(|vv| {
             let mut u = [0u8; 16];
-            reader.read_exact(&mut u).unwrap();
+            reader.read_exact(&mut u)?;
             *vv = unsafe { transmute::<[u8; 16], uint32x4_t>(u) }
         });
-        res
+        Ok(res)
     }
 
     #[inline]

--- a/arith/src/extension_field/gf2_128x4/neon.rs
+++ b/arith/src/extension_field/gf2_128x4/neon.rs
@@ -32,16 +32,13 @@ impl PartialEq for NeonGF2_128x4 {
 }
 
 impl FieldSerde for NeonGF2_128x4 {
+    const SERIALIZED_SIZE: usize = 16 * 4;
+
     #[inline(always)]
     fn serialize_into<W: std::io::Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         self.v.iter().try_for_each(|&vv| {
             writer.write_all(unsafe { transmute::<uint32x4_t, [u8; 16]>(vv) }.as_ref())
         })
-    }
-
-    #[inline(always)]
-    fn serialized_size() -> usize {
-        16 * 4
     }
 
     #[inline(always)]

--- a/arith/src/extension_field/m31_ext.rs
+++ b/arith/src/extension_field/m31_ext.rs
@@ -6,7 +6,7 @@ use std::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-use crate::{field_common, mod_reduce_u32, Field, FieldSerde, M31};
+use crate::{field_common, mod_reduce_u32, Field, FieldSerde, FieldSerdeResult, M31};
 
 use super::BinomialExtensionField;
 
@@ -19,7 +19,7 @@ field_common!(M31Ext3);
 
 impl FieldSerde for M31Ext3 {
     #[inline(always)]
-    fn serialize_into<W: Write>(&self, mut writer: W) -> std::result::Result<(), std::io::Error> {
+    fn serialize_into<W: Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         self.v[0].serialize_into(&mut writer)?;
         self.v[1].serialize_into(&mut writer)?;
         self.v[2].serialize_into(&mut writer)
@@ -33,7 +33,7 @@ impl FieldSerde for M31Ext3 {
     // FIXME: this deserialization function auto corrects invalid inputs.
     // We should use separate APIs for this and for the actual deserialization.
     #[inline(always)]
-    fn deserialize_from<R: Read>(mut reader: R) -> std::result::Result<Self, std::io::Error> {
+    fn deserialize_from<R: Read>(mut reader: R) -> FieldSerdeResult<Self> {
         Ok(M31Ext3 {
             v: [
                 M31::deserialize_from(&mut reader)?,
@@ -44,7 +44,7 @@ impl FieldSerde for M31Ext3 {
     }
 
     #[inline]
-    fn try_deserialize_from_ecc_format<R: Read>(mut reader: R) -> Result<Self, std::io::Error> {
+    fn try_deserialize_from_ecc_format<R: Read>(mut reader: R) -> FieldSerdeResult<Self> {
         let mut buf = [0u8; 32];
         reader.read_exact(&mut buf)?;
         assert!(

--- a/arith/src/extension_field/m31_ext.rs
+++ b/arith/src/extension_field/m31_ext.rs
@@ -33,14 +33,14 @@ impl FieldSerde for M31Ext3 {
     // FIXME: this deserialization function auto corrects invalid inputs.
     // We should use separate APIs for this and for the actual deserialization.
     #[inline(always)]
-    fn deserialize_from<R: Read>(mut reader: R) -> Self {
-        M31Ext3 {
+    fn deserialize_from<R: Read>(mut reader: R) -> std::result::Result<Self, std::io::Error> {
+        Ok(M31Ext3 {
             v: [
-                M31::deserialize_from(&mut reader),
-                M31::deserialize_from(&mut reader),
-                M31::deserialize_from(&mut reader),
+                M31::deserialize_from(&mut reader)?,
+                M31::deserialize_from(&mut reader)?,
+                M31::deserialize_from(&mut reader)?,
             ],
-        }
+        })
     }
 
     #[inline]

--- a/arith/src/extension_field/m31_ext.rs
+++ b/arith/src/extension_field/m31_ext.rs
@@ -19,10 +19,10 @@ field_common!(M31Ext3);
 
 impl FieldSerde for M31Ext3 {
     #[inline(always)]
-    fn serialize_into<W: Write>(&self, mut writer: W) {
-        self.v[0].serialize_into(&mut writer);
-        self.v[1].serialize_into(&mut writer);
-        self.v[2].serialize_into(&mut writer);
+    fn serialize_into<W: Write>(&self, mut writer: W) -> std::result::Result<(), std::io::Error> {
+        self.v[0].serialize_into(&mut writer)?;
+        self.v[1].serialize_into(&mut writer)?;
+        self.v[2].serialize_into(&mut writer)
     }
 
     #[inline(always)]

--- a/arith/src/extension_field/m31_ext.rs
+++ b/arith/src/extension_field/m31_ext.rs
@@ -18,16 +18,13 @@ pub struct M31Ext3 {
 field_common!(M31Ext3);
 
 impl FieldSerde for M31Ext3 {
+    const SERIALIZED_SIZE: usize = (32 / 8) * 3;
+
     #[inline(always)]
     fn serialize_into<W: Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         self.v[0].serialize_into(&mut writer)?;
         self.v[1].serialize_into(&mut writer)?;
         self.v[2].serialize_into(&mut writer)
-    }
-
-    #[inline(always)]
-    fn serialized_size() -> usize {
-        32 / 8 * 3
     }
 
     // FIXME: this deserialization function auto corrects invalid inputs.

--- a/arith/src/extension_field/m31_ext.rs
+++ b/arith/src/extension_field/m31_ext.rs
@@ -44,10 +44,7 @@ impl FieldSerde for M31Ext3 {
     }
 
     #[inline]
-    fn try_deserialize_from_ecc_format<R: Read>(mut reader: R) -> Result<Self, std::io::Error>
-    where
-        Self: Sized,
-    {
+    fn try_deserialize_from_ecc_format<R: Read>(mut reader: R) -> Result<Self, std::io::Error> {
         let mut buf = [0u8; 32];
         reader.read_exact(&mut buf)?;
         assert!(

--- a/arith/src/extension_field/m31_ext3x16.rs
+++ b/arith/src/extension_field/m31_ext3x16.rs
@@ -17,16 +17,13 @@ pub struct M31Ext3x16 {
 field_common!(M31Ext3x16);
 
 impl FieldSerde for M31Ext3x16 {
+    const SERIALIZED_SIZE: usize = (512 / 8) * 3;
+
     #[inline(always)]
     fn serialize_into<W: Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         self.v[0].serialize_into(&mut writer)?;
         self.v[1].serialize_into(&mut writer)?;
         self.v[2].serialize_into(&mut writer)
-    }
-
-    #[inline(always)]
-    fn serialized_size() -> usize {
-        512 / 8 * 3
     }
 
     // FIXME: this deserialization function auto corrects invalid inputs.

--- a/arith/src/extension_field/m31_ext3x16.rs
+++ b/arith/src/extension_field/m31_ext3x16.rs
@@ -17,10 +17,10 @@ field_common!(M31Ext3x16);
 
 impl FieldSerde for M31Ext3x16 {
     #[inline(always)]
-    fn serialize_into<W: Write>(&self, mut writer: W) {
-        self.v[0].serialize_into(&mut writer);
-        self.v[1].serialize_into(&mut writer);
-        self.v[2].serialize_into(&mut writer);
+    fn serialize_into<W: Write>(&self, mut writer: W) -> std::result::Result<(), std::io::Error> {
+        self.v[0].serialize_into(&mut writer)?;
+        self.v[1].serialize_into(&mut writer)?;
+        self.v[2].serialize_into(&mut writer)
     }
 
     #[inline(always)]

--- a/arith/src/extension_field/m31_ext3x16.rs
+++ b/arith/src/extension_field/m31_ext3x16.rs
@@ -43,10 +43,7 @@ impl FieldSerde for M31Ext3x16 {
 
     fn try_deserialize_from_ecc_format<R: Read>(
         mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error>
-    where
-        Self: Sized,
-    {
+    ) -> std::result::Result<Self, std::io::Error> {
         Ok(Self {
             v: [
                 M31x16::try_deserialize_from_ecc_format(&mut reader)?,

--- a/arith/src/extension_field/m31_ext3x16.rs
+++ b/arith/src/extension_field/m31_ext3x16.rs
@@ -31,14 +31,14 @@ impl FieldSerde for M31Ext3x16 {
     // FIXME: this deserialization function auto corrects invalid inputs.
     // We should use separate APIs for this and for the actual deserialization.
     #[inline(always)]
-    fn deserialize_from<R: Read>(mut reader: R) -> Self {
-        Self {
+    fn deserialize_from<R: Read>(mut reader: R) -> std::result::Result<Self, std::io::Error> {
+        Ok(Self {
             v: [
-                M31x16::deserialize_from(&mut reader),
-                M31x16::deserialize_from(&mut reader),
-                M31x16::deserialize_from(&mut reader),
+                M31x16::deserialize_from(&mut reader)?,
+                M31x16::deserialize_from(&mut reader)?,
+                M31x16::deserialize_from(&mut reader)?,
             ],
-        }
+        })
     }
 
     fn try_deserialize_from_ecc_format<R: Read>(

--- a/arith/src/extension_field/m31_ext3x16.rs
+++ b/arith/src/extension_field/m31_ext3x16.rs
@@ -5,7 +5,8 @@ use std::{
 };
 
 use crate::{
-    field_common, BinomialExtensionField, Field, FieldSerde, M31Ext3, M31x16, SimdField, M31,
+    field_common, BinomialExtensionField, Field, FieldSerde, FieldSerdeResult, M31Ext3, M31x16,
+    SimdField, M31,
 };
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
@@ -17,7 +18,7 @@ field_common!(M31Ext3x16);
 
 impl FieldSerde for M31Ext3x16 {
     #[inline(always)]
-    fn serialize_into<W: Write>(&self, mut writer: W) -> std::result::Result<(), std::io::Error> {
+    fn serialize_into<W: Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         self.v[0].serialize_into(&mut writer)?;
         self.v[1].serialize_into(&mut writer)?;
         self.v[2].serialize_into(&mut writer)
@@ -31,7 +32,7 @@ impl FieldSerde for M31Ext3x16 {
     // FIXME: this deserialization function auto corrects invalid inputs.
     // We should use separate APIs for this and for the actual deserialization.
     #[inline(always)]
-    fn deserialize_from<R: Read>(mut reader: R) -> std::result::Result<Self, std::io::Error> {
+    fn deserialize_from<R: Read>(mut reader: R) -> FieldSerdeResult<Self> {
         Ok(Self {
             v: [
                 M31x16::deserialize_from(&mut reader)?,
@@ -41,9 +42,7 @@ impl FieldSerde for M31Ext3x16 {
         })
     }
 
-    fn try_deserialize_from_ecc_format<R: Read>(
-        mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error> {
+    fn try_deserialize_from_ecc_format<R: Read>(mut reader: R) -> FieldSerdeResult<Self> {
         Ok(Self {
             v: [
                 M31x16::try_deserialize_from_ecc_format(&mut reader)?,

--- a/arith/src/field/bn254.rs
+++ b/arith/src/field/bn254.rs
@@ -126,10 +126,10 @@ impl FieldSerde for Fr {
     }
 
     #[inline(always)]
-    fn deserialize_from<R: Read>(mut reader: R) -> Self {
+    fn deserialize_from<R: Read>(mut reader: R) -> std::result::Result<Self, std::io::Error> {
         let mut buffer = [0u8; 32];
-        reader.read_exact(&mut buffer).unwrap();
-        Fr::from_bytes(&buffer).unwrap()
+        reader.read_exact(&mut buffer)?;
+        Ok(Fr::from_bytes(&buffer).unwrap()) // TODO: ctoption into result
     }
 
     #[inline]
@@ -138,6 +138,6 @@ impl FieldSerde for Fr {
     ) -> std::result::Result<Self, std::io::Error> {
         let mut buffer = [0u8; 32];
         reader.read_exact(&mut buffer)?;
-        Ok(Fr::from_bytes(&buffer).unwrap())
+        Ok(Fr::from_bytes(&buffer).unwrap()) // TODO: ctoption into result
     }
 }

--- a/arith/src/field/bn254.rs
+++ b/arith/src/field/bn254.rs
@@ -115,8 +115,8 @@ impl SimdField for Fr {
 
 impl FieldSerde for Fr {
     #[inline(always)]
-    fn serialize_into<W: Write>(&self, mut writer: W) {
-        writer.write_all(self.to_bytes().as_ref()).unwrap();
+    fn serialize_into<W: Write>(&self, mut writer: W) -> std::result::Result<(), std::io::Error> {
+        writer.write_all(self.to_bytes().as_ref())
     }
 
     /// size of the serialized bytes

--- a/arith/src/field/bn254.rs
+++ b/arith/src/field/bn254.rs
@@ -115,21 +115,17 @@ impl SimdField for Fr {
 }
 
 impl FieldSerde for Fr {
+    const SERIALIZED_SIZE: usize = 32;
+
     #[inline(always)]
     fn serialize_into<W: Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         writer.write_all(self.to_bytes().as_ref())?;
         Ok(())
     }
 
-    /// size of the serialized bytes
-    #[inline(always)]
-    fn serialized_size() -> usize {
-        32
-    }
-
     #[inline(always)]
     fn deserialize_from<R: Read>(mut reader: R) -> FieldSerdeResult<Self> {
-        let mut buffer = [0u8; 32];
+        let mut buffer = [0u8; Self::SERIALIZED_SIZE];
         reader.read_exact(&mut buffer)?;
         match Fr::from_bytes(&buffer).into_option() {
             Some(v) => Ok(v),
@@ -139,7 +135,7 @@ impl FieldSerde for Fr {
 
     #[inline]
     fn try_deserialize_from_ecc_format<R: Read>(mut reader: R) -> FieldSerdeResult<Self> {
-        let mut buffer = [0u8; 32];
+        let mut buffer = [0u8; Self::SERIALIZED_SIZE];
         reader.read_exact(&mut buffer)?;
         match Fr::from_bytes(&buffer).into_option() {
             Some(v) => Ok(v),

--- a/arith/src/field/bn254.rs
+++ b/arith/src/field/bn254.rs
@@ -135,10 +135,7 @@ impl FieldSerde for Fr {
     #[inline]
     fn try_deserialize_from_ecc_format<R: Read>(
         mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error>
-    where
-        Self: Sized,
-    {
+    ) -> std::result::Result<Self, std::io::Error> {
         let mut buffer = [0u8; 32];
         reader.read_exact(&mut buffer)?;
         Ok(Fr::from_bytes(&buffer).unwrap())

--- a/arith/src/field/gf2.rs
+++ b/arith/src/field/gf2.rs
@@ -35,10 +35,12 @@ impl FieldSerde for GF2 {
     }
 
     #[inline(always)]
-    fn deserialize_from<R: std::io::Read>(mut reader: R) -> Self {
+    fn deserialize_from<R: std::io::Read>(
+        mut reader: R,
+    ) -> std::result::Result<Self, std::io::Error> {
         let mut u = [0u8; 1];
-        reader.read_exact(&mut u).unwrap(); // todo: error propagation
-        GF2 { v: u[0] % 2 }
+        reader.read_exact(&mut u)?;
+        Ok(GF2 { v: u[0] % 2 })
     }
 
     #[inline(always)]

--- a/arith/src/field/gf2.rs
+++ b/arith/src/field/gf2.rs
@@ -9,7 +9,7 @@ use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 pub use gf2x8::GF2x8;
 
-use crate::{field_common, FieldSerde};
+use crate::{field_common, FieldSerde, FieldSerdeResult};
 
 use super::Field;
 
@@ -22,11 +22,9 @@ field_common!(GF2);
 
 impl FieldSerde for GF2 {
     #[inline(always)]
-    fn serialize_into<W: std::io::Write>(
-        &self,
-        mut writer: W,
-    ) -> std::result::Result<(), std::io::Error> {
-        writer.write_all(self.v.to_le_bytes().as_ref())
+    fn serialize_into<W: std::io::Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
+        writer.write_all(self.v.to_le_bytes().as_ref())?;
+        Ok(())
     }
 
     #[inline(always)]
@@ -35,18 +33,14 @@ impl FieldSerde for GF2 {
     }
 
     #[inline(always)]
-    fn deserialize_from<R: std::io::Read>(
-        mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error> {
+    fn deserialize_from<R: std::io::Read>(mut reader: R) -> FieldSerdeResult<Self> {
         let mut u = [0u8; 1];
         reader.read_exact(&mut u)?;
         Ok(GF2 { v: u[0] % 2 })
     }
 
     #[inline(always)]
-    fn try_deserialize_from_ecc_format<R: Read>(
-        mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error> {
+    fn try_deserialize_from_ecc_format<R: Read>(mut reader: R) -> FieldSerdeResult<Self> {
         let mut u = [0u8; 1];
         reader.read_exact(&mut u)?;
         Ok(GF2 { v: u[0] % 2 })

--- a/arith/src/field/gf2.rs
+++ b/arith/src/field/gf2.rs
@@ -22,8 +22,11 @@ field_common!(GF2);
 
 impl FieldSerde for GF2 {
     #[inline(always)]
-    fn serialize_into<W: std::io::Write>(&self, mut writer: W) {
-        writer.write_all(self.v.to_le_bytes().as_ref()).unwrap(); // todo: error propagation
+    fn serialize_into<W: std::io::Write>(
+        &self,
+        mut writer: W,
+    ) -> std::result::Result<(), std::io::Error> {
+        writer.write_all(self.v.to_le_bytes().as_ref())
     }
 
     #[inline(always)]

--- a/arith/src/field/gf2.rs
+++ b/arith/src/field/gf2.rs
@@ -41,10 +41,7 @@ impl FieldSerde for GF2 {
     #[inline(always)]
     fn try_deserialize_from_ecc_format<R: Read>(
         mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error>
-    where
-        Self: Sized,
-    {
+    ) -> std::result::Result<Self, std::io::Error> {
         let mut u = [0u8; 1];
         reader.read_exact(&mut u)?;
         Ok(GF2 { v: u[0] % 2 })

--- a/arith/src/field/gf2.rs
+++ b/arith/src/field/gf2.rs
@@ -31,7 +31,7 @@ impl FieldSerde for GF2 {
 
     #[inline(always)]
     fn deserialize_from<R: std::io::Read>(mut reader: R) -> FieldSerdeResult<Self> {
-        let mut u = [0u8; 1];
+        let mut u = [0u8; Self::SERIALIZED_SIZE];
         reader.read_exact(&mut u)?;
         Ok(GF2 { v: u[0] % 2 })
     }

--- a/arith/src/field/gf2.rs
+++ b/arith/src/field/gf2.rs
@@ -21,15 +21,12 @@ pub struct GF2 {
 field_common!(GF2);
 
 impl FieldSerde for GF2 {
+    const SERIALIZED_SIZE: usize = 1;
+
     #[inline(always)]
     fn serialize_into<W: std::io::Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         writer.write_all(self.v.to_le_bytes().as_ref())?;
         Ok(())
-    }
-
-    #[inline(always)]
-    fn serialized_size() -> usize {
-        1
     }
 
     #[inline(always)]

--- a/arith/src/field/gf2/gf2x8.rs
+++ b/arith/src/field/gf2/gf2x8.rs
@@ -21,7 +21,7 @@ impl FieldSerde for GF2x8 {
 
     #[inline(always)]
     fn deserialize_from<R: std::io::Read>(mut reader: R) -> FieldSerdeResult<Self> {
-        let mut u = [0u8; 1];
+        let mut u = [0u8; Self::SERIALIZED_SIZE];
         reader.read_exact(&mut u)?;
         Ok(GF2x8 { v: u[0] })
     }

--- a/arith/src/field/gf2/gf2x8.rs
+++ b/arith/src/field/gf2/gf2x8.rs
@@ -11,15 +11,12 @@ pub struct GF2x8 {
 }
 
 impl FieldSerde for GF2x8 {
+    const SERIALIZED_SIZE: usize = 1;
+
     #[inline(always)]
     fn serialize_into<W: std::io::Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         writer.write_all(self.v.to_le_bytes().as_ref())?;
         Ok(())
-    }
-
-    #[inline(always)]
-    fn serialized_size() -> usize {
-        1
     }
 
     #[inline(always)]

--- a/arith/src/field/gf2/gf2x8.rs
+++ b/arith/src/field/gf2/gf2x8.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use crate::{Field, FieldSerde, SimdField};
+use crate::{Field, FieldSerde, FieldSerdeResult, SimdField};
 
 use super::GF2;
 
@@ -12,11 +12,9 @@ pub struct GF2x8 {
 
 impl FieldSerde for GF2x8 {
     #[inline(always)]
-    fn serialize_into<W: std::io::Write>(
-        &self,
-        mut writer: W,
-    ) -> std::result::Result<(), std::io::Error> {
-        writer.write_all(self.v.to_le_bytes().as_ref())
+    fn serialize_into<W: std::io::Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
+        writer.write_all(self.v.to_le_bytes().as_ref())?;
+        Ok(())
     }
 
     #[inline(always)]
@@ -25,18 +23,14 @@ impl FieldSerde for GF2x8 {
     }
 
     #[inline(always)]
-    fn deserialize_from<R: std::io::Read>(
-        mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error> {
+    fn deserialize_from<R: std::io::Read>(mut reader: R) -> FieldSerdeResult<Self> {
         let mut u = [0u8; 1];
         reader.read_exact(&mut u)?;
         Ok(GF2x8 { v: u[0] })
     }
 
     #[inline]
-    fn try_deserialize_from_ecc_format<R: std::io::Read>(
-        mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error> {
+    fn try_deserialize_from_ecc_format<R: std::io::Read>(mut reader: R) -> FieldSerdeResult<Self> {
         let mut u = [0u8; 32];
         reader.read_exact(&mut u)?;
         Ok(GF2x8 { v: u[0] })

--- a/arith/src/field/gf2/gf2x8.rs
+++ b/arith/src/field/gf2/gf2x8.rs
@@ -12,8 +12,11 @@ pub struct GF2x8 {
 
 impl FieldSerde for GF2x8 {
     #[inline(always)]
-    fn serialize_into<W: std::io::Write>(&self, mut writer: W) {
-        writer.write_all(self.v.to_le_bytes().as_ref()).unwrap(); // todo: error propagation
+    fn serialize_into<W: std::io::Write>(
+        &self,
+        mut writer: W,
+    ) -> std::result::Result<(), std::io::Error> {
+        writer.write_all(self.v.to_le_bytes().as_ref())
     }
 
     #[inline(always)]

--- a/arith/src/field/gf2/gf2x8.rs
+++ b/arith/src/field/gf2/gf2x8.rs
@@ -25,10 +25,12 @@ impl FieldSerde for GF2x8 {
     }
 
     #[inline(always)]
-    fn deserialize_from<R: std::io::Read>(mut reader: R) -> Self {
+    fn deserialize_from<R: std::io::Read>(
+        mut reader: R,
+    ) -> std::result::Result<Self, std::io::Error> {
         let mut u = [0u8; 1];
-        reader.read_exact(&mut u).unwrap(); // todo: error propagation
-        GF2x8 { v: u[0] }
+        reader.read_exact(&mut u)?;
+        Ok(GF2x8 { v: u[0] })
     }
 
     #[inline]

--- a/arith/src/field/gf2/gf2x8.rs
+++ b/arith/src/field/gf2/gf2x8.rs
@@ -31,10 +31,7 @@ impl FieldSerde for GF2x8 {
     #[inline]
     fn try_deserialize_from_ecc_format<R: std::io::Read>(
         mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error>
-    where
-        Self: Sized,
-    {
+    ) -> std::result::Result<Self, std::io::Error> {
         let mut u = [0u8; 32];
         reader.read_exact(&mut u)?;
         Ok(GF2x8 { v: u[0] })

--- a/arith/src/field/m31.rs
+++ b/arith/src/field/m31.rs
@@ -62,10 +62,7 @@ impl FieldSerde for M31 {
     #[inline]
     fn try_deserialize_from_ecc_format<R: Read>(
         mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error>
-    where
-        Self: Sized,
-    {
+    ) -> std::result::Result<Self, std::io::Error> {
         let mut buf = [0u8; 32];
         reader.read_exact(&mut buf)?;
         assert!(

--- a/arith/src/field/m31.rs
+++ b/arith/src/field/m31.rs
@@ -39,8 +39,8 @@ field_common!(M31);
 
 impl FieldSerde for M31 {
     #[inline(always)]
-    fn serialize_into<W: Write>(&self, mut writer: W) {
-        writer.write_all(self.v.to_le_bytes().as_ref()).unwrap(); // todo: error propagation
+    fn serialize_into<W: Write>(&self, mut writer: W) -> std::result::Result<(), std::io::Error> {
+        writer.write_all(self.v.to_le_bytes().as_ref())
     }
 
     #[inline(always)]

--- a/arith/src/field/m31.rs
+++ b/arith/src/field/m31.rs
@@ -51,12 +51,12 @@ impl FieldSerde for M31 {
     // FIXME: this deserialization function auto corrects invalid inputs.
     // We should use separate APIs for this and for the actual deserialization.
     #[inline(always)]
-    fn deserialize_from<R: Read>(mut reader: R) -> Self {
+    fn deserialize_from<R: Read>(mut reader: R) -> std::result::Result<Self, std::io::Error> {
         let mut u = [0u8; 4];
-        reader.read_exact(&mut u).unwrap(); // todo: error propagation
+        reader.read_exact(&mut u)?;
         let mut v = u32::from_le_bytes(u);
         v = mod_reduce_u32(v);
-        M31 { v }
+        Ok(M31 { v })
     }
 
     #[inline]

--- a/arith/src/field/m31.rs
+++ b/arith/src/field/m31.rs
@@ -38,22 +38,19 @@ pub struct M31 {
 field_common!(M31);
 
 impl FieldSerde for M31 {
+    const SERIALIZED_SIZE: usize = 32 / 8;
+
     #[inline(always)]
     fn serialize_into<W: Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         writer.write_all(self.v.to_le_bytes().as_ref())?;
         Ok(())
     }
 
-    #[inline(always)]
-    fn serialized_size() -> usize {
-        32 / 8
-    }
-
     // FIXME: this deserialization function auto corrects invalid inputs.
     // We should use separate APIs for this and for the actual deserialization.
     #[inline(always)]
     fn deserialize_from<R: Read>(mut reader: R) -> FieldSerdeResult<Self> {
-        let mut u = [0u8; 4];
+        let mut u = [0u8; Self::SERIALIZED_SIZE];
         reader.read_exact(&mut u)?;
         let mut v = u32::from_le_bytes(u);
         v = mod_reduce_u32(v);

--- a/arith/src/field/m31.rs
+++ b/arith/src/field/m31.rs
@@ -9,7 +9,7 @@ pub mod m31_neon;
 
 use rand::RngCore;
 
-use crate::{field_common, Field, FieldSerde};
+use crate::{field_common, Field, FieldSerde, FieldSerdeResult};
 use std::{
     io::{Read, Write},
     iter::{Product, Sum},
@@ -39,8 +39,9 @@ field_common!(M31);
 
 impl FieldSerde for M31 {
     #[inline(always)]
-    fn serialize_into<W: Write>(&self, mut writer: W) -> std::result::Result<(), std::io::Error> {
-        writer.write_all(self.v.to_le_bytes().as_ref())
+    fn serialize_into<W: Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
+        writer.write_all(self.v.to_le_bytes().as_ref())?;
+        Ok(())
     }
 
     #[inline(always)]
@@ -51,7 +52,7 @@ impl FieldSerde for M31 {
     // FIXME: this deserialization function auto corrects invalid inputs.
     // We should use separate APIs for this and for the actual deserialization.
     #[inline(always)]
-    fn deserialize_from<R: Read>(mut reader: R) -> std::result::Result<Self, std::io::Error> {
+    fn deserialize_from<R: Read>(mut reader: R) -> FieldSerdeResult<Self> {
         let mut u = [0u8; 4];
         reader.read_exact(&mut u)?;
         let mut v = u32::from_le_bytes(u);
@@ -60,9 +61,7 @@ impl FieldSerde for M31 {
     }
 
     #[inline]
-    fn try_deserialize_from_ecc_format<R: Read>(
-        mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error> {
+    fn try_deserialize_from_ecc_format<R: Read>(mut reader: R) -> FieldSerdeResult<Self> {
         let mut buf = [0u8; 32];
         reader.read_exact(&mut buf)?;
         assert!(

--- a/arith/src/field/m31/m31_avx.rs
+++ b/arith/src/field/m31/m31_avx.rs
@@ -52,13 +52,13 @@ impl FieldSerde for AVXM31 {
 
     /// deserialize bytes into field
     #[inline(always)]
-    fn deserialize_from<R: Read>(mut reader: R) -> Self {
+    fn deserialize_from<R: Read>(mut reader: R) -> std::result::Result<Self, std::io::Error> {
         let mut data = [0; 64];
-        reader.read_exact(&mut data).unwrap();
+        reader.read_exact(&mut data)?;
         unsafe {
             let mut value = transmute::<[u8; 64], __m512i>(data);
             value = mod_reduce_epi32(value);
-            AVXM31 { v: value }
+            Ok(AVXM31 { v: value })
         }
     }
 

--- a/arith/src/field/m31/m31_avx.rs
+++ b/arith/src/field/m31/m31_avx.rs
@@ -40,9 +40,9 @@ field_common!(AVXM31);
 impl FieldSerde for AVXM31 {
     #[inline(always)]
     /// serialize self into bytes
-    fn serialize_into<W: Write>(&self, mut writer: W) {
+    fn serialize_into<W: Write>(&self, mut writer: W) -> std::result::Result<(), std::io::Error> {
         let data = unsafe { transmute::<__m512i, [u8; 64]>(self.v) };
-        writer.write_all(&data).unwrap();
+        writer.write_all(&data)
     }
 
     #[inline(always)]

--- a/arith/src/field/m31/m31_avx.rs
+++ b/arith/src/field/m31/m31_avx.rs
@@ -38,17 +38,14 @@ impl AVXM31 {
 field_common!(AVXM31);
 
 impl FieldSerde for AVXM31 {
+    const SERIALIZED_SIZE: usize = 512 / 8;
+
     #[inline(always)]
     /// serialize self into bytes
     fn serialize_into<W: Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         let data = unsafe { transmute::<__m512i, [u8; 64]>(self.v) };
         writer.write_all(&data)?;
         Ok(())
-    }
-
-    #[inline(always)]
-    fn serialized_size() -> usize {
-        512 / 8
     }
 
     /// deserialize bytes into field

--- a/arith/src/field/m31/m31_avx.rs
+++ b/arith/src/field/m31/m31_avx.rs
@@ -65,10 +65,7 @@ impl FieldSerde for AVXM31 {
     #[inline(always)]
     fn try_deserialize_from_ecc_format<R: Read>(
         mut reader: R,
-    ) -> std::result::Result<Self, std::io::Error>
-    where
-        Self: Sized,
-    {
+    ) -> std::result::Result<Self, std::io::Error> {
         let mut buf = [0u8; 32];
         reader.read_exact(&mut buf)?;
         assert!(

--- a/arith/src/field/m31/m31_avx.rs
+++ b/arith/src/field/m31/m31_avx.rs
@@ -51,10 +51,10 @@ impl FieldSerde for AVXM31 {
     /// deserialize bytes into field
     #[inline(always)]
     fn deserialize_from<R: Read>(mut reader: R) -> FieldSerdeResult<Self> {
-        let mut data = [0; 64];
+        let mut data = [0; Self::SERIALIZED_SIZE];
         reader.read_exact(&mut data)?;
         unsafe {
-            let mut value = transmute::<[u8; 64], __m512i>(data);
+            let mut value = transmute::<[u8; Self::SERIALIZED_SIZE], __m512i>(data);
             value = mod_reduce_epi32(value);
             Ok(AVXM31 { v: value })
         }

--- a/arith/src/field/m31/m31_neon.rs
+++ b/arith/src/field/m31/m31_neon.rs
@@ -60,13 +60,13 @@ impl FieldSerde for NeonM31 {
 
     /// deserialize bytes into field
     #[inline(always)]
-    fn deserialize_from<R: Read>(mut reader: R) -> Self {
+    fn deserialize_from<R: Read>(mut reader: R) -> std::result::Result<Self, std::io::Error> {
         let mut data = [0; 64];
-        reader.read_exact(&mut data).unwrap();
+        reader.read_exact(&mut data)?;
         unsafe {
-            NeonM31 {
+            Ok(NeonM31 {
                 v: transmute::<[u8; 64], [uint32x4_t; 4]>(data),
-            }
+            })
         }
     }
 

--- a/arith/src/field/m31/m31_neon.rs
+++ b/arith/src/field/m31/m31_neon.rs
@@ -46,17 +46,14 @@ impl NeonM31 {
 }
 
 impl FieldSerde for NeonM31 {
+    const SERIALIZED_SIZE: usize = (128 / 8) * 4;
+
     #[inline(always)]
     /// serialize self into bytes
     fn serialize_into<W: Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         let data = unsafe { transmute::<[uint32x4_t; 4], [u8; 64]>(self.v) };
         writer.write_all(&data)?;
         Ok(())
-    }
-
-    #[inline(always)]
-    fn serialized_size() -> usize {
-        128 / 8 * 4
     }
 
     /// deserialize bytes into field

--- a/arith/src/field/m31/m31_neon.rs
+++ b/arith/src/field/m31/m31_neon.rs
@@ -48,9 +48,9 @@ impl NeonM31 {
 impl FieldSerde for NeonM31 {
     #[inline(always)]
     /// serialize self into bytes
-    fn serialize_into<W: Write>(&self, mut writer: W) {
+    fn serialize_into<W: Write>(&self, mut writer: W) -> std::result::Result<(), std::io::Error> {
         let data = unsafe { transmute::<[uint32x4_t; 4], [u8; 64]>(self.v) };
-        writer.write_all(&data).unwrap();
+        writer.write_all(&data)
     }
 
     #[inline(always)]

--- a/arith/src/lib.rs
+++ b/arith/src/lib.rs
@@ -9,7 +9,6 @@ pub use extension_field::*;
 mod simd_field;
 pub use simd_field::*;
 
-// TODO: change to serdes? also make use of zerocopy
 mod serde;
 pub use serde::FieldSerde;
 

--- a/arith/src/lib.rs
+++ b/arith/src/lib.rs
@@ -10,7 +10,7 @@ mod simd_field;
 pub use simd_field::*;
 
 mod serde;
-pub use serde::FieldSerde;
+pub use serde::*;
 
 mod macros;
 

--- a/arith/src/lib.rs
+++ b/arith/src/lib.rs
@@ -9,6 +9,7 @@ pub use extension_field::*;
 mod simd_field;
 pub use simd_field::*;
 
+// TODO: change to serdes? also make use of zerocopy
 mod serde;
 pub use serde::FieldSerde;
 

--- a/arith/src/serde.rs
+++ b/arith/src/serde.rs
@@ -14,11 +14,10 @@ pub type FieldSerdeResult<T> = std::result::Result<T, FieldSerdeError>;
 
 /// Serde for Fields
 pub trait FieldSerde: Sized {
+    const SERIALIZED_SIZE: usize;
+
     /// serialize self into bytes
     fn serialize_into<W: Write>(&self, writer: W) -> FieldSerdeResult<()>;
-
-    /// size of the serialized bytes
-    fn serialized_size() -> usize;
 
     /// deserialize bytes into field
     fn deserialize_from<R: Read>(reader: R) -> FieldSerdeResult<Self>;
@@ -28,20 +27,18 @@ pub trait FieldSerde: Sized {
 }
 
 impl FieldSerde for u64 {
+    /// size of the serialized bytes
+    const SERIALIZED_SIZE: usize = 8;
+
     /// serialize u64 into bytes
     fn serialize_into<W: Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         writer.write_all(&self.to_le_bytes())?;
         Ok(())
     }
 
-    /// size of the serialized bytes
-    fn serialized_size() -> usize {
-        8
-    }
-
     /// deserialize bytes into u64
     fn deserialize_from<R: Read>(mut reader: R) -> FieldSerdeResult<Self> {
-        let mut buffer = [0u8; 8];
+        let mut buffer = [0u8; Self::SERIALIZED_SIZE];
         reader.read_exact(&mut buffer)?;
         Ok(u64::from_le_bytes(buffer))
     }

--- a/arith/src/serde.rs
+++ b/arith/src/serde.rs
@@ -3,7 +3,7 @@ use std::io::{Read, Write};
 /// Serde for Fields
 pub trait FieldSerde: Sized {
     /// serialize self into bytes
-    fn serialize_into<W: Write>(&self, writer: W);
+    fn serialize_into<W: Write>(&self, writer: W) -> std::result::Result<(), std::io::Error>;
 
     /// size of the serialized bytes
     fn serialized_size() -> usize;
@@ -19,8 +19,8 @@ pub trait FieldSerde: Sized {
 
 impl FieldSerde for u64 {
     /// serialize u64 into bytes
-    fn serialize_into<W: Write>(&self, mut writer: W) {
-        writer.write_all(&self.to_le_bytes()).unwrap();
+    fn serialize_into<W: Write>(&self, mut writer: W) -> std::result::Result<(), std::io::Error> {
+        writer.write_all(&self.to_le_bytes())
     }
 
     /// size of the serialized bytes

--- a/arith/src/serde.rs
+++ b/arith/src/serde.rs
@@ -1,26 +1,37 @@
 use std::io::{Read, Write};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum FieldSerdeError {
+    #[error("IO Error: {0}")]
+    IOError(#[from] std::io::Error),
+
+    #[error("Deserialization failure")]
+    DeserializeError,
+}
+
+pub type FieldSerdeResult<T> = std::result::Result<T, FieldSerdeError>;
 
 /// Serde for Fields
 pub trait FieldSerde: Sized {
     /// serialize self into bytes
-    fn serialize_into<W: Write>(&self, writer: W) -> std::result::Result<(), std::io::Error>;
+    fn serialize_into<W: Write>(&self, writer: W) -> FieldSerdeResult<()>;
 
     /// size of the serialized bytes
     fn serialized_size() -> usize;
 
     /// deserialize bytes into field
-    fn deserialize_from<R: Read>(reader: R) -> std::result::Result<Self, std::io::Error>;
+    fn deserialize_from<R: Read>(reader: R) -> FieldSerdeResult<Self>;
 
     /// deserialize bytes into field following ecc format
-    fn try_deserialize_from_ecc_format<R: Read>(
-        reader: R,
-    ) -> std::result::Result<Self, std::io::Error>;
+    fn try_deserialize_from_ecc_format<R: Read>(reader: R) -> FieldSerdeResult<Self>;
 }
 
 impl FieldSerde for u64 {
     /// serialize u64 into bytes
-    fn serialize_into<W: Write>(&self, mut writer: W) -> std::result::Result<(), std::io::Error> {
-        writer.write_all(&self.to_le_bytes())
+    fn serialize_into<W: Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
+        writer.write_all(&self.to_le_bytes())?;
+        Ok(())
     }
 
     /// size of the serialized bytes
@@ -29,15 +40,13 @@ impl FieldSerde for u64 {
     }
 
     /// deserialize bytes into u64
-    fn deserialize_from<R: Read>(mut reader: R) -> std::result::Result<Self, std::io::Error> {
+    fn deserialize_from<R: Read>(mut reader: R) -> FieldSerdeResult<Self> {
         let mut buffer = [0u8; 8];
         reader.read_exact(&mut buffer)?;
         Ok(u64::from_le_bytes(buffer))
     }
 
-    fn try_deserialize_from_ecc_format<R: Read>(
-        _reader: R,
-    ) -> std::result::Result<Self, std::io::Error> {
+    fn try_deserialize_from_ecc_format<R: Read>(_reader: R) -> FieldSerdeResult<Self> {
         unimplemented!("not implemented for u64")
     }
 }

--- a/arith/src/serde.rs
+++ b/arith/src/serde.rs
@@ -1,7 +1,7 @@
 use std::io::{Read, Write};
 
 /// Serde for Fields
-pub trait FieldSerde {
+pub trait FieldSerde: Sized {
     /// serialize self into bytes
     fn serialize_into<W: Write>(&self, writer: W);
 
@@ -14,9 +14,7 @@ pub trait FieldSerde {
     /// deserialize bytes into field following ecc format
     fn try_deserialize_from_ecc_format<R: Read>(
         reader: R,
-    ) -> std::result::Result<Self, std::io::Error>
-    where
-        Self: Sized;
+    ) -> std::result::Result<Self, std::io::Error>;
 }
 
 impl FieldSerde for u64 {
@@ -39,10 +37,7 @@ impl FieldSerde for u64 {
 
     fn try_deserialize_from_ecc_format<R: Read>(
         _reader: R,
-    ) -> std::result::Result<Self, std::io::Error>
-    where
-        Self: Sized,
-    {
+    ) -> std::result::Result<Self, std::io::Error> {
         unimplemented!("not implemented for u64")
     }
 }

--- a/arith/src/serde.rs
+++ b/arith/src/serde.rs
@@ -9,7 +9,7 @@ pub trait FieldSerde: Sized {
     fn serialized_size() -> usize;
 
     /// deserialize bytes into field
-    fn deserialize_from<R: Read>(reader: R) -> Self;
+    fn deserialize_from<R: Read>(reader: R) -> std::result::Result<Self, std::io::Error>;
 
     /// deserialize bytes into field following ecc format
     fn try_deserialize_from_ecc_format<R: Read>(
@@ -29,10 +29,10 @@ impl FieldSerde for u64 {
     }
 
     /// deserialize bytes into u64
-    fn deserialize_from<R: Read>(mut reader: R) -> Self {
+    fn deserialize_from<R: Read>(mut reader: R) -> std::result::Result<Self, std::io::Error> {
         let mut buffer = [0u8; 8];
-        reader.read_exact(&mut buffer).unwrap();
-        u64::from_le_bytes(buffer)
+        reader.read_exact(&mut buffer)?;
+        Ok(u64::from_le_bytes(buffer))
     }
 
     fn try_deserialize_from_ecc_format<R: Read>(

--- a/arith/src/tests/field.rs
+++ b/arith/src/tests/field.rs
@@ -248,7 +248,7 @@ fn random_serde_tests<F: Field + FieldSerde, R: RngCore>(mut rng: R, type_name: 
     for _ in 0..1000 {
         let a = F::random_unsafe(&mut rng);
         let mut buffer = vec![];
-        a.serialize_into(&mut buffer);
+        assert!(a.serialize_into(&mut buffer).is_ok());
         let mut cursor = Cursor::new(buffer);
         let b = F::deserialize_from(&mut cursor);
         assert_eq!(a, b);

--- a/arith/src/tests/field.rs
+++ b/arith/src/tests/field.rs
@@ -251,6 +251,8 @@ fn random_serde_tests<F: Field + FieldSerde, R: RngCore>(mut rng: R, type_name: 
         assert!(a.serialize_into(&mut buffer).is_ok());
         let mut cursor = Cursor::new(buffer);
         let b = F::deserialize_from(&mut cursor);
+        assert!(b.is_ok());
+        let b = b.unwrap();
         assert_eq!(a, b);
     }
     end_timer!(start);

--- a/arith/src/tests/gf2.rs
+++ b/arith/src/tests/gf2.rs
@@ -23,7 +23,7 @@ fn test_field() {
 fn test_custom_serde_vectorize_gf2() {
     let a = GF2x8::from(0);
     let mut buffer = vec![];
-    a.serialize_into(&mut buffer);
+    assert!(a.serialize_into(&mut buffer).is_ok());
     let mut cursor = Cursor::new(buffer);
     let b = GF2x8::deserialize_from(&mut cursor);
     assert_eq!(a, b);

--- a/arith/src/tests/gf2.rs
+++ b/arith/src/tests/gf2.rs
@@ -26,5 +26,7 @@ fn test_custom_serde_vectorize_gf2() {
     assert!(a.serialize_into(&mut buffer).is_ok());
     let mut cursor = Cursor::new(buffer);
     let b = GF2x8::deserialize_from(&mut cursor);
+    assert!(b.is_ok());
+    let b = b.unwrap();
     assert_eq!(a, b);
 }

--- a/arith/src/tests/gf2_128.rs
+++ b/arith/src/tests/gf2_128.rs
@@ -22,7 +22,7 @@ fn test_field() {
 fn test_custom_serde_vectorize_gf2() {
     let a = GF2_128::from(0);
     let mut buffer = vec![];
-    a.serialize_into(&mut buffer);
+    assert!(a.serialize_into(&mut buffer).is_ok());
     let mut cursor = Cursor::new(buffer);
     let b = GF2_128::deserialize_from(&mut cursor);
     assert_eq!(a, b);

--- a/arith/src/tests/gf2_128.rs
+++ b/arith/src/tests/gf2_128.rs
@@ -25,5 +25,7 @@ fn test_custom_serde_vectorize_gf2() {
     assert!(a.serialize_into(&mut buffer).is_ok());
     let mut cursor = Cursor::new(buffer);
     let b = GF2_128::deserialize_from(&mut cursor);
+    assert!(b.is_ok());
+    let b = b.unwrap();
     assert_eq!(a, b);
 }

--- a/arith/src/tests/m31.rs
+++ b/arith/src/tests/m31.rs
@@ -28,5 +28,7 @@ fn test_custom_serde_vectorize_m31() {
     assert!(a.serialize_into(&mut buffer).is_ok());
     let mut cursor = Cursor::new(buffer);
     let b = M31x16::deserialize_from(&mut cursor);
+    assert!(b.is_ok());
+    let b = b.unwrap();
     assert_eq!(a, b);
 }

--- a/arith/src/tests/m31.rs
+++ b/arith/src/tests/m31.rs
@@ -25,7 +25,7 @@ fn test_field() {
 fn test_custom_serde_vectorize_m31() {
     let a = M31x16::from(256 + 2);
     let mut buffer = vec![];
-    a.serialize_into(&mut buffer);
+    assert!(a.serialize_into(&mut buffer).is_ok());
     let mut cursor = Cursor::new(buffer);
     let b = M31x16::deserialize_from(&mut cursor);
     assert_eq!(a, b);

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -416,6 +416,7 @@ impl<C: GKRConfig> Segment<C> {
     }
 }
 
+#[derive(Default)]
 pub struct RecursiveCircuit<C: GKRConfig> {
     pub segments: Vec<Segment<C>>,
     pub layers: Vec<SegmentId>,
@@ -425,10 +426,7 @@ const MAGIC_NUM: u64 = 3770719418566461763; // b'CIRCUIT4'
 
 impl<C: GKRConfig> RecursiveCircuit<C> {
     pub fn load(filename: &str) -> Self {
-        let mut ret = RecursiveCircuit::<C> {
-            segments: Vec::new(),
-            layers: Vec::new(),
-        };
+        let mut ret = RecursiveCircuit::<C>::default();
         let file_bytes = fs::read(filename).unwrap();
         let mut cursor = Cursor::new(file_bytes);
 
@@ -466,12 +464,7 @@ impl<C: GKRConfig> RecursiveCircuit<C> {
             let mut ret_layer = CircuitLayer {
                 input_var_num: layer_seg.i_var_num,
                 output_var_num: layer_seg.o_var_num,
-                input_vals: vec![],
-                output_vals: vec![],
-                mul: vec![],
-                add: vec![],
-                const_: vec![],
-                uni: vec![],
+                ..Default::default()
             };
             for (leaf_seg_id, leaf_allocs) in leaves {
                 let leaf_seg = &self.segments[leaf_seg_id];

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -25,8 +25,8 @@ fn dump_proof_and_claimed_v<F: Field + FieldSerde>(proof: &Proof, claimed_v: &F)
 fn load_proof_and_claimed_v<F: Field + FieldSerde>(bytes: &[u8]) -> (Proof, F) {
     let mut cursor = Cursor::new(bytes);
 
-    let proof = Proof::deserialize_from(&mut cursor);
-    let claimed_v = F::deserialize_from(&mut cursor);
+    let proof = Proof::deserialize_from(&mut cursor).unwrap(); // TODO: error propagation
+    let claimed_v = F::deserialize_from(&mut cursor).unwrap(); // TODO: error propagation
 
     (proof, claimed_v)
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -16,8 +16,8 @@ use warp::{http::StatusCode, reply, Filter};
 fn dump_proof_and_claimed_v<F: Field + FieldSerde>(proof: &Proof, claimed_v: &F) -> Vec<u8> {
     let mut bytes = Vec::new();
 
-    proof.serialize_into(&mut bytes);
-    claimed_v.serialize_into(&mut bytes);
+    proof.serialize_into(&mut bytes).unwrap(); // TODO: error propagation
+    claimed_v.serialize_into(&mut bytes).unwrap(); // TODO: error propagation
 
     bytes
 }

--- a/src/poly_commit/raw.rs
+++ b/src/poly_commit/raw.rs
@@ -32,7 +32,7 @@ impl<C: GKRConfig> RawCommitment<C> {
     #[inline]
     pub fn deserialize_from<R: Read>(mut reader: R, poly_size: usize) -> Self {
         let poly_vals = (0..poly_size)
-            .map(|_| C::SimdCircuitField::deserialize_from(&mut reader))
+            .map(|_| C::SimdCircuitField::deserialize_from(&mut reader).unwrap()) // TODO: error propagation
             .collect();
 
         RawCommitment { poly_vals }

--- a/src/poly_commit/raw.rs
+++ b/src/poly_commit/raw.rs
@@ -3,7 +3,7 @@
 
 use std::io::{Read, Write};
 
-use arith::{Field, FieldSerde};
+use arith::{Field, FieldSerde, FieldSerdeResult};
 
 use crate::{GKRConfig, MultiLinearPoly};
 
@@ -20,10 +20,7 @@ impl<C: GKRConfig> RawCommitment<C> {
     }
 
     #[inline]
-    pub fn serialize_into<W: Write>(
-        &self,
-        mut writer: W,
-    ) -> std::result::Result<(), std::io::Error> {
+    pub fn serialize_into<W: Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         self.poly_vals
             .iter()
             .try_for_each(|v| v.serialize_into(&mut writer))

--- a/src/poly_commit/raw.rs
+++ b/src/poly_commit/raw.rs
@@ -20,10 +20,13 @@ impl<C: GKRConfig> RawCommitment<C> {
     }
 
     #[inline]
-    pub fn serialize_into<W: Write>(&self, mut writer: W) {
+    pub fn serialize_into<W: Write>(
+        &self,
+        mut writer: W,
+    ) -> std::result::Result<(), std::io::Error> {
         self.poly_vals
             .iter()
-            .for_each(|v| v.serialize_into(&mut writer));
+            .try_for_each(|v| v.serialize_into(&mut writer))
     }
 
     #[inline]

--- a/src/prover/fiat_shamir.rs
+++ b/src/prover/fiat_shamir.rs
@@ -46,7 +46,7 @@ impl Transcript {
     pub fn append_f<C: GKRConfig>(&mut self, f: C::Field) {
         let cur_size = self.proof.bytes.len();
         self.proof.bytes.resize(cur_size + C::Field::SIZE, 0);
-        f.serialize_into(&mut self.proof.bytes[cur_size..]);
+        f.serialize_into(&mut self.proof.bytes[cur_size..]).unwrap(); // TODO: error propagation
     }
 
     #[inline]

--- a/src/prover/linear_gkr.rs
+++ b/src/prover/linear_gkr.rs
@@ -83,7 +83,7 @@ impl<C: GKRConfig> Prover<C> {
         let commitment = RawCommitment::<C>::new(&c.layers[0].input_vals);
 
         let mut buffer = vec![];
-        commitment.serialize_into(&mut buffer);
+        commitment.serialize_into(&mut buffer).unwrap(); // TODO: error propagation
         let mut transcript = Transcript::new();
         transcript.append_u8_slice(&buffer);
 

--- a/src/prover/linear_gkr.rs
+++ b/src/prover/linear_gkr.rs
@@ -21,7 +21,7 @@ pub(crate) fn grind<C: GKRConfig>(transcript: &mut Transcript, config: &Config<C
     let initial_hash = transcript.challenge_fs::<C>(num_field_elements);
     initial_hash
         .iter()
-        .for_each(|h| h.serialize_into(&mut hash_bytes));
+        .for_each(|h| h.serialize_into(&mut hash_bytes).unwrap());
 
     assert!(hash_bytes.len() >= 32, "hash len: {}", hash_bytes.len());
     hash_bytes.truncate(32);

--- a/src/prover/linear_gkr.rs
+++ b/src/prover/linear_gkr.rs
@@ -21,7 +21,7 @@ pub(crate) fn grind<C: GKRConfig>(transcript: &mut Transcript, config: &Config<C
     let initial_hash = transcript.challenge_fs::<C>(num_field_elements);
     initial_hash
         .iter()
-        .for_each(|h| h.serialize_into(&mut hash_bytes).unwrap());
+        .for_each(|h| h.serialize_into(&mut hash_bytes).unwrap()); // TODO: error propagation
 
     assert!(hash_bytes.len() >= 32, "hash len: {}", hash_bytes.len());
     hash_bytes.truncate(32);
@@ -33,18 +33,10 @@ pub(crate) fn grind<C: GKRConfig>(transcript: &mut Transcript, config: &Config<C
     end_timer!(timer);
 }
 
+#[derive(Default)]
 pub struct Prover<C: GKRConfig> {
     config: Config<C>,
     sp: GkrScratchpad<C>,
-}
-
-impl<C: GKRConfig> Default for Prover<C> {
-    fn default() -> Self {
-        Self {
-            config: Config::<C>::default(),
-            sp: GkrScratchpad::default(),
-        }
-    }
 }
 
 impl<C: GKRConfig> Prover<C> {

--- a/src/prover/proof.rs
+++ b/src/prover/proof.rs
@@ -30,14 +30,14 @@ impl Proof {
 
 impl FieldSerde for Proof {
     #[inline(always)]
-    fn serialize_into<W: Write>(&self, mut writer: W) {
-        (self.bytes.len() as u64).serialize_into(&mut writer);
-        writer.write_all(&self.bytes).unwrap();
+    fn serialize_into<W: Write>(&self, mut writer: W) -> std::result::Result<(), std::io::Error> {
+        (self.bytes.len() as u64).serialize_into(&mut writer)?;
+        writer.write_all(&self.bytes)
     }
 
     #[inline(always)]
     fn serialized_size() -> usize {
-        0 // proof is not a fixed size
+        unimplemented!("not implemented for Proof")
     }
 
     #[inline(always)]

--- a/src/prover/proof.rs
+++ b/src/prover/proof.rs
@@ -22,7 +22,7 @@ impl Proof {
 
     #[inline(always)]
     pub fn get_next_and_step<F: Field + FieldSerde>(&mut self) -> F {
-        let ret = F::deserialize_from(&self.bytes[self.idx..]);
+        let ret = F::deserialize_from(&self.bytes[self.idx..]).unwrap(); // TODO: error propagation
         self.step(F::SIZE);
         ret
     }
@@ -41,14 +41,14 @@ impl FieldSerde for Proof {
     }
 
     #[inline(always)]
-    fn deserialize_from<R: Read>(mut reader: R) -> Self {
-        let proof_len = u64::deserialize_from(&mut reader) as usize;
+    fn deserialize_from<R: Read>(mut reader: R) -> std::result::Result<Self, std::io::Error> {
+        let proof_len = u64::deserialize_from(&mut reader)? as usize;
         let mut proof = vec![0u8; proof_len];
         reader.read_exact(&mut proof).unwrap();
-        Self {
+        Ok(Self {
             idx: 0,
             bytes: proof,
-        }
+        })
     }
 
     fn try_deserialize_from_ecc_format<R: Read>(

--- a/src/prover/proof.rs
+++ b/src/prover/proof.rs
@@ -53,10 +53,7 @@ impl FieldSerde for Proof {
 
     fn try_deserialize_from_ecc_format<R: Read>(
         _reader: R,
-    ) -> std::result::Result<Self, std::io::Error>
-    where
-        Self: Sized,
-    {
+    ) -> std::result::Result<Self, std::io::Error> {
         unimplemented!("not implemented for Proof")
     }
 }

--- a/src/prover/proof.rs
+++ b/src/prover/proof.rs
@@ -29,16 +29,13 @@ impl Proof {
 }
 
 impl FieldSerde for Proof {
+    const SERIALIZED_SIZE: usize = panic!("not implemented for Proof");
+
     #[inline(always)]
     fn serialize_into<W: Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         (self.bytes.len() as u64).serialize_into(&mut writer)?;
         writer.write_all(&self.bytes)?;
         Ok(())
-    }
-
-    #[inline(always)]
-    fn serialized_size() -> usize {
-        unimplemented!("not implemented for Proof")
     }
 
     #[inline(always)]

--- a/src/prover/proof.rs
+++ b/src/prover/proof.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Write};
 
-use arith::{Field, FieldSerde};
+use arith::{Field, FieldSerde, FieldSerdeResult};
 
 /// Proof. In the serialized mode.
 #[derive(Debug, Clone, Default)]
@@ -30,9 +30,10 @@ impl Proof {
 
 impl FieldSerde for Proof {
     #[inline(always)]
-    fn serialize_into<W: Write>(&self, mut writer: W) -> std::result::Result<(), std::io::Error> {
+    fn serialize_into<W: Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
         (self.bytes.len() as u64).serialize_into(&mut writer)?;
-        writer.write_all(&self.bytes)
+        writer.write_all(&self.bytes)?;
+        Ok(())
     }
 
     #[inline(always)]
@@ -41,7 +42,7 @@ impl FieldSerde for Proof {
     }
 
     #[inline(always)]
-    fn deserialize_from<R: Read>(mut reader: R) -> std::result::Result<Self, std::io::Error> {
+    fn deserialize_from<R: Read>(mut reader: R) -> FieldSerdeResult<Self> {
         let proof_len = u64::deserialize_from(&mut reader)? as usize;
         let mut proof = vec![0u8; proof_len];
         reader.read_exact(&mut proof).unwrap();
@@ -51,9 +52,7 @@ impl FieldSerde for Proof {
         })
     }
 
-    fn try_deserialize_from_ecc_format<R: Read>(
-        _reader: R,
-    ) -> std::result::Result<Self, std::io::Error> {
+    fn try_deserialize_from_ecc_format<R: Read>(_reader: R) -> FieldSerdeResult<Self> {
         unimplemented!("not implemented for Proof")
     }
 }


### PR DESCRIPTION
Minor PR, containing following changes:
- Exposing `FieldSerdeError` from `std::io::Error` with `thiserror`, serialize and deserialize return with `Result` rather than `unwrap`.
- Moving `serialized_size` trait method into a trait constant `SERIALIZED_SIZE: usize`.  The thinking here is, the type implementing `FieldSerde` has a const size that is known in compile time, so the size should be known from the type rather than an instance.