### PR TITLE
remove avx512 instructions from avx256

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,17 @@ jobs:
       - run: RUSTFLAGS="-C target-cpu=native" cargo test -p bi-kzg --release
       - run: RUSTFLAGS="-C target-cpu=native" cargo test --no-default-features --release
       - run: RUSTFLAGS="-C target-cpu=native" cargo test --all-features --release
+  Test-linux-avx256:
+    name: Test-linux-avx256
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: . "$HOME/.cargo/env"
+      - run: cargo run --bin=dev-setup --release
+      - run: RUSTFLAGS="-C target-cpu=native" cargo test -p arith --release --features avx256
+      - run: RUSTFLAGS="-C target-cpu=native" cargo test -p bi-kzg --release
+      - run: RUSTFLAGS="-C target-cpu=native" cargo test --release --features avx256
   Bench-linux-m31-ext3:
     name: Bench-linux-m31-ext3
     runs-on: 7950x3d

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ path = "src/utils.rs"
 default = []
 # default = [ "grinding" ]
 grinding = []
+avx256 = ["arith/avx256"]
 
 [workspace]
 members = ["arith", "bi-kzg"]

--- a/arith/src/extension_field/gf2_128x8/avx256.rs
+++ b/arith/src/extension_field/gf2_128x8/avx256.rs
@@ -128,11 +128,11 @@ impl Field for AVX256GF2_128x8 {
     fn is_zero(&self) -> bool {
         unsafe {
             let zero = _mm256_setzero_si256();
-            let cmp_0 = _mm256_cmpeq_epi64_mask(self.data[0], zero)
-                & _mm256_cmpeq_epi64_mask(self.data[1], zero);
-            let cmp_1 = _mm256_cmpeq_epi64_mask(self.data[2], zero)
-                & _mm256_cmpeq_epi64_mask(self.data[3], zero);
-            (cmp_0 & cmp_1) == 0xF // All 16 64-bit integers are equal (zero)
+            let cmp0 = _mm256_movemask_epi8(_mm256_cmpeq_epi8(self.data[0], zero));
+            let cmp1 = _mm256_movemask_epi8(_mm256_cmpeq_epi8(self.data[1], zero));
+            let cmp2 = _mm256_movemask_epi8(_mm256_cmpeq_epi8(self.data[2], zero));
+            let cmp3 = _mm256_movemask_epi8(_mm256_cmpeq_epi8(self.data[3], zero));
+            (cmp0 & cmp1 & cmp2 & cmp3) == !0i32
         }
     }
 
@@ -438,11 +438,11 @@ impl PartialEq for AVX256GF2_128x8 {
     #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         unsafe {
-            let cmp_0 = _mm256_cmpeq_epi64_mask(self.data[0], other.data[0])
-                & _mm256_cmpeq_epi64_mask(self.data[1], other.data[1]);
-            let cmp_1 = _mm256_cmpeq_epi64_mask(self.data[2], other.data[2])
-                & _mm256_cmpeq_epi64_mask(self.data[3], other.data[3]);
-            (cmp_0 & cmp_1) == 0xF // All 16 64-bit integers are equal
+            let cmp0 = _mm256_movemask_epi8(_mm256_cmpeq_epi8(self.data[0], other.data[0]));
+            let cmp1 = _mm256_movemask_epi8(_mm256_cmpeq_epi8(self.data[1], other.data[1]));
+            let cmp2 = _mm256_movemask_epi8(_mm256_cmpeq_epi8(self.data[2], other.data[2]));
+            let cmp3 = _mm256_movemask_epi8(_mm256_cmpeq_epi8(self.data[3], other.data[3]));
+            (cmp0 & cmp1 & cmp2 & cmp3) == !0i32
         }
     }
 }
@@ -578,22 +578,6 @@ fn mul_internal(a: &AVX256GF2_128x8, b: &AVX256GF2_128x8) -> AVX256GF2_128x8 {
     }
 }
 
-// abcdefgh -> aacceegg
-#[inline(always)]
-pub fn duplicate_even_bits(byte: u8) -> u8 {
-    let even_bits = byte & 0b10101010;
-    let even_bits_shifted = even_bits >> 1;
-    even_bits | even_bits_shifted
-}
-
-// abcdefgh -> bbddffhh
-#[inline(always)]
-pub fn duplicate_odd_bits(byte: u8) -> u8 {
-    let odd_bits = byte & 0b01010101;
-    let odd_bits_shifted = odd_bits << 1;
-    odd_bits | odd_bits_shifted
-}
-
 impl ExtensionField for AVX256GF2_128x8 {
     const DEGREE: usize = GF2_128::DEGREE;
 
@@ -614,17 +598,23 @@ impl ExtensionField for AVX256GF2_128x8 {
 
     #[inline(always)]
     fn mul_by_base_field(&self, base: &Self::BaseField) -> Self {
-        let mask_even = duplicate_even_bits(base.v);
-        let mask_odd = duplicate_odd_bits(base.v);
+        // -1 -> 0b11111111
+        let v0 = -(((base.v >> 7) & 1u8) as i64);
+        let v1 = -(((base.v >> 6) & 1u8) as i64);
+        let v2 = -(((base.v >> 5) & 1u8) as i64);
+        let v3 = -(((base.v >> 4) & 1u8) as i64);
+        let v4 = -(((base.v >> 3) & 1u8) as i64);
+        let v5 = -(((base.v >> 2) & 1u8) as i64);
+        let v6 = -(((base.v >> 1) & 1u8) as i64);
+        let v7 = -((base.v & 1u8) as i64);
 
-        Self {
-            data: [
-                unsafe { _mm256_maskz_mov_epi64(mask_even, self.data[0]) },
-                unsafe { _mm256_maskz_mov_epi64(mask_even, self.data[1]) },
-                unsafe { _mm256_maskz_mov_epi64(mask_odd, self.data[2]) },
-                unsafe { _mm256_maskz_mov_epi64(mask_odd, self.data[3]) },
-            ],
-        }
+        let mut res = *self;
+        res.data[0] = unsafe { _mm256_and_si256(res.data[0], _mm256_set_epi64x(v0, v0, v2, v2)) };
+        res.data[1] = unsafe { _mm256_and_si256(res.data[1], _mm256_set_epi64x(v4, v4, v6, v6)) };
+        res.data[2] = unsafe { _mm256_and_si256(res.data[2], _mm256_set_epi64x(v1, v1, v3, v3)) };
+        res.data[3] = unsafe { _mm256_and_si256(res.data[3], _mm256_set_epi64x(v5, v5, v7, v7)) };
+
+        res
     }
 
     #[inline(always)]
@@ -666,8 +656,8 @@ impl ExtensionField for AVX256GF2_128x8 {
 
                 // compute the reduced polynomial
                 let reduction = {
-                    let odd_elements = _mm256_maskz_compress_epi64(0b10101010, msb);
-                    let mask = _mm256_maskz_expand_epi64(0b01010101, odd_elements);
+                    let odd_elements = _mm256_and_si256(msb, _mm256_set_epi64x(-1, 0, -1, 0));
+                    let mask = _mm256_permute4x64_epi64::<0b00110001>(odd_elements);
                     let multiplier = _mm256_set1_epi64x(0x87);
                     _mm256_mul_epu32(multiplier, mask)
                 };

--- a/arith/src/field/m31/m31_avx256.rs
+++ b/arith/src/field/m31/m31_avx256.rs
@@ -110,11 +110,11 @@ impl Field for AVXM31 {
     fn is_zero(&self) -> bool {
         // value is either zero or 0x7FFFFFFF
         unsafe {
-            let pcmp = _mm256_cmpeq_epi32_mask(self.v[0], PACKED_0)
-                & _mm256_cmpeq_epi32_mask(self.v[1], PACKED_0);
-            let pcmp2 = _mm256_cmpeq_epi32_mask(self.v[0], PACKED_MOD)
-                & _mm256_cmpeq_epi32_mask(self.v[1], PACKED_MOD);
-            (pcmp | pcmp2) == 0xFF
+            let cmp0 = _mm256_movemask_epi8(_mm256_cmpeq_epi32(self.v[0], PACKED_0));
+            let cmp1 = _mm256_movemask_epi8(_mm256_cmpeq_epi32(self.v[1], PACKED_0));
+            let cmp2 = _mm256_movemask_epi8(_mm256_cmpeq_epi32(self.v[0], PACKED_MOD));
+            let cmp3 = _mm256_movemask_epi8(_mm256_cmpeq_epi32(self.v[1], PACKED_MOD));
+            (cmp0 | cmp2) == !0i32 && (cmp1 | cmp3) == !0i32
         }
     }
 
@@ -336,34 +336,32 @@ impl PartialEq for AVXM31 {
     #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         unsafe {
-            let cmp0 = _mm256_cmpeq_epi32_mask(self.v[0], other.v[0]);
-            let cmp1 = _mm256_cmpeq_epi32_mask(self.v[1], other.v[1]);
-            (cmp0 & cmp1) == 0xFF
+            let cmp0 = _mm256_movemask_epi8(_mm256_cmpeq_epi8(self.v[0], other.v[0]));
+            let cmp1 = _mm256_movemask_epi8(_mm256_cmpeq_epi8(self.v[1], other.v[1]));
+            (cmp0 & cmp1) == !0i32
         }
     }
 }
 
 #[inline]
 #[must_use]
-fn mask_movehdup_epi32(src: __m256i, k: __mmask8, a: __m256i) -> __m256i {
+fn movehdup_epi32(a: __m256i) -> __m256i {
     // The instruction is only available in the floating-point flavor; this distinction is only for
     // historical reasons and no longer matters. We cast to floats, do the thing, and cast back.
     unsafe {
-        let src = _mm256_castsi256_ps(src);
         let a = _mm256_castsi256_ps(a);
-        _mm256_castps_si256(_mm256_mask_movehdup_ps(src, k, a))
+        _mm256_castps_si256(_mm256_movehdup_ps(a))
     }
 }
 
 #[inline]
 #[must_use]
-fn mask_moveldup_epi32(src: __m256i, k: __mmask8, a: __m256i) -> __m256i {
+fn moveldup_epi32(a: __m256i) -> __m256i {
     // The instruction is only available in the floating-point flavor; this distinction is only for
     // historical reasons and no longer matters. We cast to floats, do the thing, and cast back.
     unsafe {
-        let src = _mm256_castsi256_ps(src);
         let a = _mm256_castsi256_ps(a);
-        _mm256_castps_si256(_mm256_mask_moveldup_ps(src, k, a))
+        _mm256_castps_si256(_mm256_moveldup_ps(a))
     }
 }
 
@@ -377,8 +375,8 @@ fn add(lhs: __m256i, rhs: __m256i) -> __m256i {
     }
 }
 
-const EVENS: __mmask8 = 0b01010101;
-const ODDS: __mmask8 = 0b10101010;
+const EVENS: i32 = 0b01010101;
+const ODDS: i32 = 0b10101010;
 
 impl Mul<&M31> for AVXM31 {
     type Output = AVXM31;
@@ -398,8 +396,10 @@ impl Mul<&M31> for AVXM31 {
                 let prod_odd_dbl = _mm256_mul_epu32(lhs_odd_dbl, rhs_odd);
                 let prod_evn_dbl = _mm256_mul_epu32(lhs_evn_dbl, rhs_evn);
 
-                let prod_lo_dbl = mask_moveldup_epi32(prod_evn_dbl, ODDS, prod_odd_dbl);
-                let prod_hi = mask_movehdup_epi32(prod_odd_dbl, EVENS, prod_evn_dbl);
+                let prod_odd_dup = moveldup_epi32(prod_odd_dbl);
+                let prod_evn_dup = movehdup_epi32(prod_evn_dbl);
+                let prod_lo_dbl = _mm256_blend_epi32(prod_evn_dbl, prod_odd_dup, ODDS);
+                let prod_hi = _mm256_blend_epi32(prod_odd_dbl, prod_evn_dup, EVENS);
                 // Right shift to undo the doubling.
                 let prod_lo = _mm256_srli_epi32::<1>(prod_lo_dbl);
 
@@ -448,14 +448,6 @@ impl Neg for AVXM31 {
             },
         }
     }
-}
-
-#[inline]
-#[must_use]
-fn movehdup_epi32(x: __m256i) -> __m256i {
-    // The instruction is only available in the floating-point flavor; this distinction is only for
-    // historical reasons and no longer matters. We cast to floats, duplicate, and cast back.
-    unsafe { _mm256_castps_si256(_mm256_movehdup_ps(_mm256_castsi256_ps(x))) }
 }
 
 #[inline(always)]
@@ -513,8 +505,10 @@ fn mul_internal(a: &AVXM31, b: &AVXM31) -> AVXM31 {
             let prod_odd_dbl = _mm256_mul_epu32(lhs_odd_dbl, rhs_odd);
             let prod_evn_dbl = _mm256_mul_epu32(lhs_evn_dbl, rhs_evn);
 
-            let prod_lo_dbl = mask_moveldup_epi32(prod_evn_dbl, ODDS, prod_odd_dbl);
-            let prod_hi = mask_movehdup_epi32(prod_odd_dbl, EVENS, prod_evn_dbl);
+            let prod_odd_dup = moveldup_epi32(prod_odd_dbl);
+            let prod_evn_dup = movehdup_epi32(prod_evn_dbl);
+            let prod_lo_dbl = _mm256_blend_epi32(prod_evn_dbl, prod_odd_dup, ODDS);
+            let prod_hi = _mm256_blend_epi32(prod_odd_dbl, prod_evn_dup, EVENS);
             // Right shift to undo the doubling.
             let prod_lo = _mm256_srli_epi32::<1>(prod_lo_dbl);
 


### PR DESCRIPTION
Also updated `Cargo.toml` to provide the feature, and add ci test on avx2 only machine (ubuntu-latest).

Only `extension_field::gf2_128x8::avx256` and `field::m31::m31_avx256` are updated. Other fields like `gf2_128x4` might still use these avx512 instructions, but they are not used at all, so they are not touched in this PR.