### PR TITLE
Fix expander-exec

### DIFF
--- a/circuit/src/expander_circuit.rs
+++ b/circuit/src/expander_circuit.rs
@@ -148,56 +148,17 @@ impl<C: GKRConfig> Circuit<C> {
         rc.flatten()
     }
 
-    /// temp fix the issue where witness is not SIMDed
-    pub fn load_non_simd_witness_file(&mut self, filename: &str, pack_size: usize) {
+    pub fn load_non_simd_witness_file(&mut self, filename: &str) {
         let file_bytes = fs::read(filename).unwrap();
-        let cursor = Cursor::new(file_bytes);
-        let mut witness = Witness::<C>::deserialize_from(cursor);
-
-        assert_eq!(witness.num_witnesses, 1);
-        witness.num_witnesses = pack_size;
-        witness.values = (0..pack_size)
-            .flat_map(|_| witness.values.clone())
-            .collect();
-
-        let private_input_size = 1 << self.log_input_size();
-        let public_input_size = witness.num_public_inputs_per_witness;
-        let total_size = private_input_size + public_input_size;
-
-        assert_eq!(witness.num_private_inputs_per_witness, private_input_size);
-        #[allow(clippy::comparison_chain)]
-        if witness.num_witnesses < C::get_field_pack_size() {
-            panic!("Not enough witness");
-        } else if witness.num_witnesses > C::get_field_pack_size() {
-            println!("Warning: dropping additional witnesses");
-        }
-
-        let input = &witness.values;
-        let private_input = &mut self.layers[0].input_vals;
-        let public_input = &mut self.public_input;
-
-        private_input.clear();
-        public_input.clear();
-
-        for i in 0..private_input_size {
-            let mut private_wit_i = vec![];
-            for j in 0..C::get_field_pack_size() {
-                private_wit_i.push(input[j * total_size + i]);
-            }
-            private_input.push(C::SimdCircuitField::pack(&private_wit_i));
-        }
-
-        for i in 0..public_input_size {
-            let mut public_wit_i = vec![];
-            for j in 0..C::get_field_pack_size() {
-                public_wit_i.push(input[j * total_size + private_input_size + i]);
-            }
-            public_input.push(C::SimdCircuitField::pack(&public_wit_i));
-        }
+        self.load_witness_bytes(&file_bytes, true);
     }
 
     pub fn load_witness_file(&mut self, filename: &str) {
         let file_bytes = fs::read(filename).unwrap();
+        self.load_witness_bytes(&file_bytes, false);
+    }
+
+    pub fn load_witness_bytes(&mut self, file_bytes: &[u8], allow_padding: bool) {
         let cursor = Cursor::new(file_bytes);
         let witness = Witness::<C>::deserialize_from(cursor);
 
@@ -208,9 +169,25 @@ impl<C: GKRConfig> Circuit<C> {
         assert_eq!(witness.num_private_inputs_per_witness, private_input_size);
         #[allow(clippy::comparison_chain)]
         if witness.num_witnesses < C::get_field_pack_size() {
-            panic!("Not enough witness");
+            if !allow_padding {
+                panic!(
+                    "Not enough witness, expected {}, got {}",
+                    C::get_field_pack_size(),
+                    witness.num_witnesses
+                );
+            } else {
+                println!(
+                    "Warning: padding witnesses, expected {}, got {}",
+                    C::get_field_pack_size(),
+                    witness.num_witnesses
+                );
+            }
         } else if witness.num_witnesses > C::get_field_pack_size() {
-            println!("Warning: dropping additional witnesses");
+            println!(
+                "Warning: dropping additional witnesses, expected {}, got {}",
+                C::get_field_pack_size(),
+                witness.num_witnesses
+            );
         }
 
         let input = &witness.values;
@@ -222,16 +199,22 @@ impl<C: GKRConfig> Circuit<C> {
 
         for i in 0..private_input_size {
             let mut private_wit_i = vec![];
-            for j in 0..C::get_field_pack_size() {
+            for j in 0..C::get_field_pack_size().min(witness.num_witnesses) {
                 private_wit_i.push(input[j * total_size + i]);
+            }
+            while private_wit_i.len() < C::get_field_pack_size() {
+                private_wit_i.push(private_wit_i[0]);
             }
             private_input.push(C::SimdCircuitField::pack(&private_wit_i));
         }
 
         for i in 0..public_input_size {
             let mut public_wit_i = vec![];
-            for j in 0..C::get_field_pack_size() {
+            for j in 0..C::get_field_pack_size().min(witness.num_witnesses) {
                 public_wit_i.push(input[j * total_size + private_input_size + i]);
+            }
+            while public_wit_i.len() < C::get_field_pack_size() {
+                public_wit_i.push(public_wit_i[0]);
             }
             public_input.push(C::SimdCircuitField::pack(&public_wit_i));
         }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -25,6 +25,10 @@ pub const SENTINEL_BN254: [u8; 32] = [
     69, 80, 184, 41, 160, 49, 225, 114, 78, 100, 48,
 ];
 
+pub const SENTINEL_GF2: [u8; 32] = [
+    2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+];
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub enum GKRScheme {
     #[default]

--- a/gkr/src/exec.rs
+++ b/gkr/src/exec.rs
@@ -1,210 +1,227 @@
-// use std::{
-//     fs,
-//     io::Cursor,
-//     process::exit,
-//     sync::{Arc, Mutex},
-// };
+use std::{
+    fs,
+    io::Cursor,
+    process::exit,
+    sync::{Arc, Mutex},
+};
 
-// use arith::{Field, FieldSerde};
-// use expander_rs::{
-//     BN254ConfigSha2, Circuit, Config, FieldType, GKRConfig, GKRScheme, M31ExtConfigSha2, MPIConfig,
-//     Proof, Prover, Verifier, SENTINEL_BN254, SENTINEL_M31,
-// };
-// use log::{debug, info};
-// use warp::{http::StatusCode, reply, Filter};
+use arith::{Field, FieldSerde, FieldSerdeError};
+use circuit::Circuit;
+use config::{
+    BN254ConfigSha2, Config, FieldType, GF2ExtConfigSha2, GKRConfig, GKRScheme, M31ExtConfigSha2,
+    MPIConfig, SENTINEL_BN254, SENTINEL_GF2, SENTINEL_M31,
+};
+use log::{debug, info};
+use transcript::Proof;
+use warp::{http::StatusCode, reply, Filter};
 
-// fn dump_proof_and_claimed_v<F: Field + FieldSerde>(proof: &Proof, claimed_v: &F) -> Vec<u8> {
-//     let mut bytes = Vec::new();
+fn dump_proof_and_claimed_v<F: Field + FieldSerde>(
+    proof: &Proof,
+    claimed_v: &F,
+) -> Result<Vec<u8>, FieldSerdeError> {
+    let mut bytes = Vec::new();
 
-//     proof.serialize_into(&mut bytes).unwrap(); // TODO: error propagation
-//     claimed_v.serialize_into(&mut bytes).unwrap(); // TODO: error propagation
+    proof.serialize_into(&mut bytes)?;
+    claimed_v.serialize_into(&mut bytes)?;
 
-//     bytes
-// }
+    Ok(bytes)
+}
 
-// fn load_proof_and_claimed_v<F: Field + FieldSerde>(bytes: &[u8]) -> (Proof, F) {
-//     let mut cursor = Cursor::new(bytes);
+fn load_proof_and_claimed_v<F: Field + FieldSerde>(
+    bytes: &[u8],
+) -> Result<(Proof, F), FieldSerdeError> {
+    let mut cursor = Cursor::new(bytes);
 
-//     let proof = Proof::deserialize_from(&mut cursor).unwrap(); // TODO: error propagation
-//     let claimed_v = F::deserialize_from(&mut cursor).unwrap(); // TODO: error propagation
+    let proof = Proof::deserialize_from(&mut cursor)?;
+    let claimed_v = F::deserialize_from(&mut cursor)?;
 
-//     (proof, claimed_v)
-// }
+    Ok((proof, claimed_v))
+}
 
-// fn detect_field_type_from_circuit_file(circuit_file: &str) -> FieldType {
-//     // read last 32 byte of sentinel field element to determine field type
-//     let bytes = fs::read(circuit_file).expect("Unable to read circuit file.");
-//     let field_bytes = &bytes[8..8 + 32];
-//     match field_bytes.try_into().unwrap() {
-//         SENTINEL_M31 => FieldType::M31,
-//         SENTINEL_BN254 => FieldType::BN254,
-//         _ => {
-//             println!("Unknown field type. Field byte value: {:?}", field_bytes);
-//             exit(1);
-//         }
-//     }
-// }
+fn detect_field_type_from_circuit_file(circuit_file: &str) -> FieldType {
+    // read last 32 byte of sentinel field element to determine field type
+    let bytes = fs::read(circuit_file).expect("Unable to read circuit file.");
+    let field_bytes = &bytes[8..8 + 32];
+    match field_bytes.try_into().unwrap() {
+        SENTINEL_M31 => FieldType::M31,
+        SENTINEL_BN254 => FieldType::BN254,
+        SENTINEL_GF2 => FieldType::GF2,
+        _ => {
+            println!("Unknown field type. Field byte value: {:?}", field_bytes);
+            exit(1);
+        }
+    }
+}
 
-// async fn run_command<'a, C: GKRConfig>(
-//     command: &str,
-//     circuit_file: &str,
-//     config: Config<C>,
-//     args: &[String],
-// ) {
-//     match command {
-//         "prove" => {
-//             let witness_file = &args[3];
-//             let output_file = &args[4];
-//             let mut circuit = Circuit::<C>::load_circuit(circuit_file);
-//             circuit.load_witness_file(witness_file);
-//             circuit.evaluate();
-//             let mut prover = Prover::new(&config);
-//             prover.prepare_mem(&circuit);
-//             let (claimed_v, proof) = prover.prove(&mut circuit);
-//             let bytes = dump_proof_and_claimed_v(&proof, &claimed_v);
-//             fs::write(output_file, bytes).expect("Unable to write proof to file.");
-//         }
-//         "verify" => {
-//             let witness_file = &args[3];
-//             let output_file = &args[4];
-//             let mut circuit = Circuit::<C>::load_circuit(circuit_file);
-//             circuit.load_witness_file(witness_file);
-//             let bytes = fs::read(output_file).expect("Unable to read proof from file.");
-//             let (proof, claimed_v) = load_proof_and_claimed_v(&bytes);
-//             let verifier = Verifier::new(&config);
-//             assert!(verifier.verify(&mut circuit, &claimed_v, &proof));
-//             println!("success");
-//         }
-//         "serve" => {
-//             let host: [u8; 4] = args[3]
-//                 .split('.')
-//                 .map(|s| s.parse().unwrap())
-//                 .collect::<Vec<u8>>()
-//                 .try_into()
-//                 .unwrap();
-//             let port = args[4].parse().unwrap();
-//             let circuit = Circuit::<C>::load_circuit(circuit_file);
-//             let mut prover = Prover::new(&config);
-//             prover.prepare_mem(&circuit);
-//             let verifier = Verifier::new(&config);
-//             let circuit = Arc::new(Mutex::new(circuit));
-//             let circuit_clone_for_verifier = circuit.clone();
-//             let prover = Arc::new(Mutex::new(prover));
-//             let verifier = Arc::new(Mutex::new(verifier));
-//             let ready_time = chrono::offset::Utc::now();
-//             let ready = warp::path("ready").map(move || {
-//                 info!("Received ready request.");
-//                 reply::with_status(format!("Ready since {:?}", ready_time), StatusCode::OK)
-//             });
-//             let prove =
-//                 warp::path("prove")
-//                     .and(warp::body::bytes())
-//                     .map(move |bytes: bytes::Bytes| {
-//                         info!("Received prove request.");
-//                         let witness_bytes: Vec<u8> = bytes.to_vec();
-//                         let mut circuit = circuit.lock().unwrap();
-//                         let mut prover = prover.lock().unwrap();
-//                         if circuit.load_witness_bytes(&witness_bytes).is_err() {
-//                             reply::with_status(vec![], StatusCode::BAD_REQUEST)
-//                         } else {
-//                             circuit.evaluate();
-//                             let (claimed_v, proof) = prover.prove(&mut circuit);
-//                             reply::with_status(
-//                                 dump_proof_and_claimed_v(&proof, &claimed_v),
-//                                 StatusCode::OK,
-//                             )
-//                         }
-//                     });
-//             let verify =
-//                 warp::path("verify")
-//                     .and(warp::body::bytes())
-//                     .map(move |bytes: bytes::Bytes| {
-//                         info!("Received verify request.");
-//                         let witness_and_proof_bytes: Vec<u8> = bytes.to_vec();
-//                         let length_of_witness_bytes =
-//                             u64::from_le_bytes(witness_and_proof_bytes[0..8].try_into().unwrap())
-//                                 as usize;
-//                         let length_of_proof_bytes =
-//                             u64::from_le_bytes(witness_and_proof_bytes[8..16].try_into().unwrap())
-//                                 as usize;
-//                         let witness_bytes =
-//                             &witness_and_proof_bytes[16..16 + length_of_witness_bytes];
-//                         let proof_bytes = &witness_and_proof_bytes[16 + length_of_witness_bytes
-//                             ..16 + length_of_witness_bytes + length_of_proof_bytes];
+async fn run_command<'a, C: GKRConfig>(
+    command: &str,
+    circuit_file: &str,
+    config: Config<C>,
+    args: &[String],
+) {
+    match command {
+        "prove" => {
+            let witness_file = &args[3];
+            let output_file = &args[4];
+            let mut circuit = Circuit::<C>::load_circuit(circuit_file);
+            circuit.load_witness_file(witness_file);
+            circuit.evaluate();
+            let mut prover = gkr::Prover::new(&config);
+            prover.prepare_mem(&circuit);
+            let (claimed_v, proof) = prover.prove(&mut circuit);
+            let bytes =
+                dump_proof_and_claimed_v(&proof, &claimed_v).expect("Unable to serialize proof.");
+            fs::write(output_file, bytes).expect("Unable to write proof to file.");
+        }
+        "verify" => {
+            let witness_file = &args[3];
+            let output_file = &args[4];
+            let mut circuit = Circuit::<C>::load_circuit(circuit_file);
+            circuit.load_witness_file(witness_file);
+            let bytes = fs::read(output_file).expect("Unable to read proof from file.");
+            let (proof, claimed_v) =
+                load_proof_and_claimed_v(&bytes).expect("Unable to deserialize proof.");
+            let verifier = gkr::Verifier::new(&config);
+            let public_input = circuit.public_input.clone();
+            assert!(verifier.verify(&mut circuit, &public_input, &claimed_v, &proof));
+            println!("success");
+        }
+        "serve" => {
+            let host: [u8; 4] = args[3]
+                .split('.')
+                .map(|s| s.parse().unwrap())
+                .collect::<Vec<u8>>()
+                .try_into()
+                .unwrap();
+            let port = args[4].parse().unwrap();
+            let circuit = Circuit::<C>::load_circuit(circuit_file);
+            let mut prover = gkr::Prover::new(&config);
+            prover.prepare_mem(&circuit);
+            let verifier = gkr::Verifier::new(&config);
+            let circuit = Arc::new(Mutex::new(circuit));
+            let circuit_clone_for_verifier = circuit.clone();
+            let prover = Arc::new(Mutex::new(prover));
+            let verifier = Arc::new(Mutex::new(verifier));
+            let ready_time = chrono::offset::Utc::now();
+            let ready = warp::path("ready").map(move || {
+                info!("Received ready request.");
+                reply::with_status(format!("Ready since {:?}", ready_time), StatusCode::OK)
+            });
+            let prove =
+                warp::path("prove")
+                    .and(warp::body::bytes())
+                    .map(move |bytes: bytes::Bytes| {
+                        info!("Received prove request.");
+                        let witness_bytes: Vec<u8> = bytes.to_vec();
+                        let mut circuit = circuit.lock().unwrap();
+                        let mut prover = prover.lock().unwrap();
+                        circuit.load_witness_bytes(&witness_bytes, true);
+                        circuit.evaluate();
+                        let (claimed_v, proof) = prover.prove(&mut circuit);
+                        reply::with_status(
+                            dump_proof_and_claimed_v(&proof, &claimed_v).unwrap(),
+                            StatusCode::OK,
+                        )
+                    });
+            let verify =
+                warp::path("verify")
+                    .and(warp::body::bytes())
+                    .map(move |bytes: bytes::Bytes| {
+                        info!("Received verify request.");
+                        let witness_and_proof_bytes: Vec<u8> = bytes.to_vec();
+                        let length_of_witness_bytes =
+                            u64::from_le_bytes(witness_and_proof_bytes[0..8].try_into().unwrap())
+                                as usize;
+                        let length_of_proof_bytes =
+                            u64::from_le_bytes(witness_and_proof_bytes[8..16].try_into().unwrap())
+                                as usize;
+                        let witness_bytes =
+                            &witness_and_proof_bytes[16..16 + length_of_witness_bytes];
+                        let proof_bytes = &witness_and_proof_bytes[16 + length_of_witness_bytes
+                            ..16 + length_of_witness_bytes + length_of_proof_bytes];
 
-//                         let mut circuit = circuit_clone_for_verifier.lock().unwrap();
-//                         let verifier = verifier.lock().unwrap();
-//                         if circuit.load_witness_bytes(witness_bytes).is_err() {
-//                             "failure".to_string()
-//                         } else {
-//                             let (proof, claimed_v) = load_proof_and_claimed_v(proof_bytes);
-//                             if verifier.verify(&mut circuit, &claimed_v, &proof) {
-//                                 "success".to_string()
-//                             } else {
-//                                 "failure".to_string()
-//                             }
-//                         }
-//                     });
-//             warp::serve(
-//                 warp::post()
-//                     .and(prove.or(verify))
-//                     .or(warp::get().and(ready)),
-//             )
-//             .run((host, port))
-//             .await;
-//         }
-//         _ => {
-//             println!("Invalid command.");
-//         }
-//     }
-// }
+                        let mut circuit = circuit_clone_for_verifier.lock().unwrap();
+                        let verifier = verifier.lock().unwrap();
+                        circuit.load_witness_bytes(witness_bytes, true);
+                        let public_input = circuit.public_input.clone();
+                        let (proof, claimed_v) = load_proof_and_claimed_v(proof_bytes).unwrap();
+                        if verifier.verify(&mut circuit, &public_input, &claimed_v, &proof) {
+                            "success".to_string()
+                        } else {
+                            "failure".to_string()
+                        }
+                    });
+            warp::serve(
+                warp::post()
+                    .and(prove.or(verify))
+                    .or(warp::get().and(ready)),
+            )
+            .run((host, port))
+            .await;
+        }
+        _ => {
+            println!("Invalid command.");
+        }
+    }
+}
 
-// #[tokio::main]
-// async fn main() {
-//     // examples:
-//     // expander-exec prove <input:circuit_file> <input:witness_file> <output:proof>
-//     // expander-exec verify <input:circuit_file> <input:witness_file> <input:proof>
-//     // expander-exec serve <input:circuit_file> <input:ip> <input:port>
-//     let mpi_config = MPIConfig::new();
+#[tokio::main]
+async fn main() {
+    // examples:
+    // expander-exec prove <input:circuit_file> <input:witness_file> <output:proof>
+    // expander-exec verify <input:circuit_file> <input:witness_file> <input:proof>
+    // expander-exec serve <input:circuit_file> <input:ip> <input:port>
+    let mpi_config = MPIConfig::new();
 
-//     let args = std::env::args().collect::<Vec<String>>();
-//     if args.len() < 4 {
-//         println!(
-//             "Usage: expander-exec prove <input:circuit_file> <input:witness_file> <output:proof>"
-//         );
-//         println!(
-//             "Usage: expander-exec verify <input:circuit_file> <input:witness_file> <input:proof>"
-//         );
-//         println!("Usage: expander-exec serve <input:circuit_file> <input:host> <input:port>");
-//         return;
-//     }
-//     let command = &args[1];
-//     let circuit_file = &args[2];
-//     let field_type = detect_field_type_from_circuit_file(circuit_file);
-//     debug!("field type: {:?}", field_type);
-//     match field_type {
-//         FieldType::M31 => {
-//             run_command::<M31ExtConfigSha2>(
-//                 command,
-//                 circuit_file,
-//                 Config::<M31ExtConfigSha2>::new(GKRScheme::Vanilla, mpi_config.clone()),
-//                 &args,
-//             )
-//             .await;
-//         }
-//         FieldType::BN254 => {
-//             run_command::<BN254ConfigSha2>(
-//                 command,
-//                 circuit_file,
-//                 Config::<BN254ConfigSha2>::new(GKRScheme::Vanilla, mpi_config.clone()),
-//                 &args,
-//             )
-//             .await;
-//         }
-//         _ => unreachable!(),
-//     }
+    let args = std::env::args().collect::<Vec<String>>();
+    if args.len() < 4 {
+        println!(
+            "Usage: expander-exec prove <input:circuit_file> <input:witness_file> <output:proof>"
+        );
+        println!(
+            "Usage: expander-exec verify <input:circuit_file> <input:witness_file> <input:proof>"
+        );
+        println!("Usage: expander-exec serve <input:circuit_file> <input:host> <input:port>");
+        return;
+    }
+    let command = &args[1];
+    if command != "prove" && command != "verify" && command != "serve" {
+        println!("Invalid command.");
+        return;
+    }
+    let circuit_file = &args[2];
+    let field_type = detect_field_type_from_circuit_file(circuit_file);
+    debug!("field type: {:?}", field_type);
+    match field_type {
+        FieldType::M31 => {
+            run_command::<M31ExtConfigSha2>(
+                command,
+                circuit_file,
+                Config::<M31ExtConfigSha2>::new(GKRScheme::Vanilla, mpi_config.clone()),
+                &args,
+            )
+            .await;
+        }
+        FieldType::BN254 => {
+            run_command::<BN254ConfigSha2>(
+                command,
+                circuit_file,
+                Config::<BN254ConfigSha2>::new(GKRScheme::Vanilla, mpi_config.clone()),
+                &args,
+            )
+            .await;
+        }
+        FieldType::GF2 => {
+            run_command::<GF2ExtConfigSha2>(
+                command,
+                circuit_file,
+                Config::<GF2ExtConfigSha2>::new(GKRScheme::Vanilla, mpi_config.clone()),
+                &args,
+            )
+            .await
+        }
+        _ => unreachable!(),
+    }
 
-//     MPIConfig::finalize();
-// }
-
-fn main() {}
+    MPIConfig::finalize();
+}

--- a/gkr/src/exec.rs
+++ b/gkr/src/exec.rs
@@ -220,7 +220,6 @@ async fn main() {
             )
             .await
         }
-        _ => unreachable!(),
     }
 
     MPIConfig::finalize();

--- a/gkr/src/main.rs
+++ b/gkr/src/main.rs
@@ -121,7 +121,7 @@ fn run_benchmark<C: GKRConfig>(args: &Args, config: Config<C>) {
     match args.scheme.as_str() {
         "keccak" => circuit_template.load_witness_file(witness_path),
         "poseidon" => match C::FIELD_TYPE {
-            FieldType::M31 => circuit_template.load_non_simd_witness_file(witness_path, 16),
+            FieldType::M31 => circuit_template.load_non_simd_witness_file(witness_path),
             _ => unreachable!("not supported"),
         },
 

--- a/gkr/src/main_mpi.rs
+++ b/gkr/src/main_mpi.rs
@@ -108,7 +108,7 @@ fn run_benchmark<C: GKRConfig>(args: &Args, config: Config<C>) {
     match args.scheme.as_str() {
         "keccak" => circuit.load_witness_file(witness_path),
         "poseidon" => match C::FIELD_TYPE {
-            FieldType::M31 => circuit.load_non_simd_witness_file(witness_path, 16),
+            FieldType::M31 => circuit.load_non_simd_witness_file(witness_path),
             _ => unreachable!("not supported"),
         },
 

--- a/readme.md
+++ b/readme.md
@@ -72,13 +72,13 @@ cargo run --bin=dev-setup --release
 Command template:
 
 ```sh
-RUSTFLAGS="-C target-cpu=native" cargo run --release -- -f [fr|m31ext3] -t [#threads] -s [keccak|poseidon]
+RUSTFLAGS="-C target-cpu=native" cargo run --release --bin gkr -- -f [fr|m31ext3] -t [#threads] -s [keccak|poseidon]
 ```
 
 Concretely if you are running on a 16 physical core CPU for Bn256 scalar field:
 
 ```sh
-RUSTFLAGS="-C target-cpu=native" cargo run --release -- -f fr -t 16
+RUSTFLAGS="-C target-cpu=native" cargo run --release --bin gkr -- -f fr -t 16
 ```
 
 ## Correctness test
@@ -103,9 +103,9 @@ RUSTFLAGS="-C target-cpu=native" cargo run --bin expander-exec --release -- serv
 Example:
 
 ```sh
-RUSTFLAGS="-C target-cpu=native" cargo run --bin expander-exec --release -- prove ./data/circuit.txt ./data/witness.txt ./data/out.bin
-RUSTFLAGS="-C target-cpu=native" cargo run --bin expander-exec --release -- verify ./data/circuit.txt ./data/witness.txt ./data/out.bin
-RUSTFLAGS="-C target-cpu=native" cargo run --bin expander-exec --release -- serve ./data/circuit.txt 127.0.0.1 3030
+RUSTFLAGS="-C target-cpu=native" mpiexec -n 1 cargo run --bin expander-exec --release -- prove ./data/circuit_m31.txt ./data/witness_m31.txt ./data/out_m31.bin
+RUSTFLAGS="-C target-cpu=native" mpiexec -n 1 cargo run --bin expander-exec --release -- verify ./data/circuit_m31.txt ./data/witness_m31.txt ./data/out_m31.bin
+RUSTFLAGS="-C target-cpu=native" mpiexec -n 1 cargo run --bin expander-exec --release -- serve ./data/circuit_m31.txt 127.0.0.1 3030
 ```
 
 To test the service started by `expander-exec serve`, you can use the following command:


### PR DESCRIPTION
Tested `prove` and `verify` with `gkr/data/circuit-*.txt`, all 3 fields work well.

Also tested `serve` with current compiler ([here](https://github.com/PolyhedraZK/ExpanderCompilerCollection/blob/master/ecgo/integration/expander_exec.go#L49)), it works.