### PR TITLE
Reuse eq_evals in prover, verifier, and recursive verifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           cargo run --bin=dev-setup --release
           cargo build --all-features --release
           cargo test --all-features --release --workspace
+          ./scripts/test_recursion.py
 
   gkr-e2e:
     name: Benchmark (${{ matrix.os }}${{ matrix.feature != '' && format(', {0}', matrix.feature) || '' }}, ${{ matrix.field }})

--- a/gkr/src/exec.rs
+++ b/gkr/src/exec.rs
@@ -130,7 +130,6 @@ async fn run_command<'a, C: GKRConfig>(
                         let mut circuit = circuit.lock().unwrap();
                         let mut prover = prover.lock().unwrap();
                         circuit.load_witness_bytes(&witness_bytes, true);
-                        circuit.evaluate();
                         let (claimed_v, proof) = prover.prove(&mut circuit);
                         reply::with_status(
                             dump_proof_and_claimed_v(&proof, &claimed_v).unwrap(),

--- a/gkr/src/prover/gkr.rs
+++ b/gkr/src/prover/gkr.rs
@@ -41,8 +41,7 @@ pub fn gkr_prove<C: GKRConfig, T: Transcript<C::ChallengeField>>(
         r_mpi.push(transcript.generate_challenge_field_element());
     }
 
-    let mut alpha = C::ChallengeField::one();
-    let mut beta = None;
+    let mut alpha = None;
 
     let output_vals = &circuit.layers.last().unwrap().output_vals;
 
@@ -75,22 +74,19 @@ pub fn gkr_prove<C: GKRConfig, T: Transcript<C::ChallengeField>>(
             &r_simd,
             &r_mpi,
             alpha,
-            beta,
             transcript,
             sp,
             mpi_config,
+            i == layer_num - 1,
         );
-        alpha = transcript.generate_challenge_field_element();
-
-        mpi_config.root_broadcast(&mut alpha);
 
         if rz1.is_some() {
             // TODO: try broadcast beta.unwrap directly
             let mut tmp = transcript.generate_challenge_field_element();
             mpi_config.root_broadcast(&mut tmp);
-            beta = Some(tmp)
+            alpha = Some(tmp)
         } else {
-            beta = None;
+            alpha = None;
         }
     }
 

--- a/sumcheck/src/scratch_pad.rs
+++ b/sumcheck/src/scratch_pad.rs
@@ -19,7 +19,6 @@ pub struct ProverScratchPad<C: GKRConfig> {
 
     pub eq_evals_at_rx: Vec<C::ChallengeField>,
     pub eq_evals_at_rz0: Vec<C::ChallengeField>,
-    pub eq_evals_at_rz1: Vec<C::ChallengeField>,
     pub eq_evals_at_r_simd0: Vec<C::ChallengeField>,
     pub eq_evals_at_r_mpi0: Vec<C::ChallengeField>,
     pub eq_evals_first_half: Vec<C::ChallengeField>,
@@ -27,6 +26,8 @@ pub struct ProverScratchPad<C: GKRConfig> {
 
     pub gate_exists_5: Vec<bool>,
     pub gate_exists_1: Vec<bool>,
+
+    pub phase2_coef: C::ChallengeField,
 }
 
 impl<C: GKRConfig> ProverScratchPad<C> {
@@ -45,7 +46,6 @@ impl<C: GKRConfig> ProverScratchPad<C> {
 
             eq_evals_at_rx: vec![C::ChallengeField::default(); max_input_num],
             eq_evals_at_rz0: vec![C::ChallengeField::default(); max_output_num],
-            eq_evals_at_rz1: vec![C::ChallengeField::default(); max_output_num],
             eq_evals_at_r_simd0: vec![C::ChallengeField::default(); C::get_field_pack_size()],
             eq_evals_at_r_mpi0: vec![C::ChallengeField::default(); mpi_world_size],
             eq_evals_first_half: vec![
@@ -65,6 +65,7 @@ impl<C: GKRConfig> ProverScratchPad<C> {
 
             gate_exists_5: vec![false; max_input_num],
             gate_exists_1: vec![false; max_input_num],
+            phase2_coef: C::ChallengeField::ZERO,
         }
     }
 }
@@ -72,7 +73,6 @@ impl<C: GKRConfig> ProverScratchPad<C> {
 pub struct VerifierScratchPad<C: GKRConfig> {
     // ====== for evaluating cst, add and mul ======
     pub eq_evals_at_rz0: Vec<C::ChallengeField>,
-    pub eq_evals_at_rz1: Vec<C::ChallengeField>,
     pub eq_evals_at_r_simd: Vec<C::ChallengeField>,
     pub eq_evals_at_r_mpi: Vec<C::ChallengeField>,
 
@@ -145,7 +145,6 @@ impl<C: GKRConfig> VerifierScratchPad<C> {
 
         Self {
             eq_evals_at_rz0: vec![C::ChallengeField::zero(); max_io_size],
-            eq_evals_at_rz1: vec![C::ChallengeField::zero(); max_io_size],
             eq_evals_at_r_simd: vec![C::ChallengeField::zero(); simd_size],
             eq_evals_at_r_mpi: vec![C::ChallengeField::zero(); config.mpi_config.world_size()],
 

--- a/sumcheck/src/sumcheck.rs
+++ b/sumcheck/src/sumcheck.rs
@@ -17,19 +17,28 @@ pub fn sumcheck_prove_gkr_layer<C: GKRConfig, T: Transcript<C::ChallengeField>>(
     rz1: &Option<Vec<C::ChallengeField>>,
     r_simd: &[C::ChallengeField],
     r_mpi: &[C::ChallengeField],
-    alpha: C::ChallengeField,
-    beta: Option<C::ChallengeField>,
+    alpha: Option<C::ChallengeField>,
     transcript: &mut T,
     sp: &mut ProverScratchPad<C>,
     mpi_config: &MPIConfig,
+    is_output_layer: bool,
 ) -> (
     Vec<C::ChallengeField>,
     Option<Vec<C::ChallengeField>>,
     Vec<C::ChallengeField>,
     Vec<C::ChallengeField>,
 ) {
-    let mut helper =
-        SumcheckGkrVanillaHelper::new(layer, rz0, rz1, r_simd, r_mpi, alpha, beta, sp, mpi_config);
+    let mut helper = SumcheckGkrVanillaHelper::new(
+        layer,
+        rz0,
+        rz1,
+        r_simd,
+        r_mpi,
+        alpha,
+        sp,
+        mpi_config,
+        is_output_layer,
+    );
 
     helper.prepare_simd();
     helper.prepare_mpi();


### PR DESCRIPTION
1. $(\alpha, \beta) \rightarrow (1, \alpha)$ to combine the two claims in a layer.
2. Optimization: In prover, verifier, recursive verifier: reuse eq evals from previous layer if possible. constraints: 9.05M $\rightarrow$ 8.25M
3. Add mpi+recursion to ci.