### PR TITLE
[Doc] Fixes broken link in the root readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ This is the *rust version* of the "core" repo.
 
 For more technical introduction, visit our markdown files [here](https://github.com/PolyhedraZK/Expander-cpp/tree/master/docs/doc.md).
 
-And [here](./tests/gkr_correctness.rs) for an example on how to use the gkr lib.
+And [here](./gkr/src/tests/gkr_correctness.rs) for an example on how to use the gkr lib.
 
 This is a core repo for our prover, to write circuits on our prover, please visit [our compiler](https://github.com/PolyhedraZK/ExpanderCompilerCollection)
 


### PR DESCRIPTION
This pull request includes a small update to the `readme.md` file to correct the file path for an example on how to use the GKR library.

* [`readme.md`](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L31-R31): Updated the file path for the GKR library example from `./tests/gkr_correctness.rs` to `./gkr/src/tests/gkr_correctness.rs`.