### PR TITLE
Minor: Typo fixing for `GF2` and tree bench shorten

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,7 +2362,6 @@ dependencies = [
  "criterion",
  "gf2",
  "gf2_128",
- "mersenne31",
  "rayon",
  "sha2",
  "tynm",

--- a/arith/gf2/src/gf2.rs
+++ b/arith/gf2/src/gf2.rs
@@ -1,4 +1,4 @@
-// Galios field over 2^128
+// Galois field over 2^128
 // credit to intel for the original implementation
 // https://www.intel.com/content/dam/develop/external/us/en/documents/clmul-wp-rev-2-02-2014-04-20.pdf
 
@@ -37,7 +37,7 @@ impl FieldSerde for GF2 {
 impl Field for GF2 {
     // still will pack 8 bits into a u8
 
-    const NAME: &'static str = "Galios Field 2";
+    const NAME: &'static str = "Galois Field 2";
 
     const SIZE: usize = 1;
 

--- a/arith/gf2/src/gf2x128.rs
+++ b/arith/gf2/src/gf2x128.rs
@@ -1,3 +1,9 @@
+use std::mem::transmute;
+
+use arith::{Field, SimdField};
+
+use crate::{GF2x64, GF2};
+
 #[cfg(target_arch = "x86_64")]
 mod avx;
 #[cfg(target_arch = "x86_64")]
@@ -7,3 +13,41 @@ pub type GF2x128 = avx::AVXGF2x128;
 mod neon;
 #[cfg(target_arch = "aarch64")]
 pub type GF2x128 = neon::NeonGF2x128;
+
+impl SimdField for GF2x128 {
+    type Scalar = GF2;
+
+    const PACK_SIZE: usize = 128;
+
+    #[inline(always)]
+    fn scale(&self, challenge: &Self::Scalar) -> Self {
+        if challenge.v == 0 {
+            <Self as Field>::ZERO
+        } else {
+            *self
+        }
+    }
+
+    #[inline(always)]
+    fn pack(base_vec: &[Self::Scalar]) -> Self {
+        assert_eq!(base_vec.len(), Self::PACK_SIZE);
+        let mut packed_to_gf2x64 = [GF2x64::ZERO; Self::PACK_SIZE / GF2x64::PACK_SIZE];
+        packed_to_gf2x64
+            .iter_mut()
+            .zip(base_vec.chunks(GF2x64::PACK_SIZE))
+            .for_each(|(gf2x64, pack)| *gf2x64 = GF2x64::pack(pack));
+
+        unsafe { transmute(packed_to_gf2x64) }
+    }
+
+    #[inline(always)]
+    fn unpack(&self) -> Vec<Self::Scalar> {
+        let packed_to_gf2x64: [GF2x64; Self::PACK_SIZE / GF2x64::PACK_SIZE] =
+            unsafe { transmute(*self) };
+
+        packed_to_gf2x64
+            .iter()
+            .flat_map(|packed| packed.unpack())
+            .collect()
+    }
+}

--- a/arith/gf2/src/gf2x128/avx.rs
+++ b/arith/gf2/src/gf2x128/avx.rs
@@ -4,9 +4,9 @@ use std::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-use arith::{Field, FieldSerde, FieldSerdeResult, SimdField};
+use arith::{Field, FieldSerde, FieldSerdeResult};
 
-use crate::{GF2x64, GF2};
+use crate::GF2;
 
 #[derive(Debug, Clone, Copy)]
 pub struct AVXGF2x128 {
@@ -37,7 +37,7 @@ impl FieldSerde for AVXGF2x128 {
 }
 
 impl Field for AVXGF2x128 {
-    const NAME: &'static str = "Galios Field 2 SIMD 128";
+    const NAME: &'static str = "AVX Galois Field 2 SIMD 128";
 
     const SIZE: usize = 128 / 8;
 
@@ -301,43 +301,5 @@ impl From<GF2> for AVXGF2x128 {
         } else {
             AVXGF2x128::ONE
         }
-    }
-}
-
-impl SimdField for AVXGF2x128 {
-    type Scalar = GF2;
-
-    const PACK_SIZE: usize = 128;
-
-    #[inline(always)]
-    fn scale(&self, challenge: &Self::Scalar) -> Self {
-        if challenge.v == 0 {
-            Self::ZERO
-        } else {
-            *self
-        }
-    }
-
-    #[inline(always)]
-    fn pack(base_vec: &[Self::Scalar]) -> Self {
-        assert_eq!(base_vec.len(), Self::PACK_SIZE);
-        let mut packed_to_gf2x64 = [GF2x64::ZERO; Self::PACK_SIZE / GF2x64::PACK_SIZE];
-        packed_to_gf2x64
-            .iter_mut()
-            .zip(base_vec.chunks(GF2x64::PACK_SIZE))
-            .for_each(|(gf2x64, pack)| *gf2x64 = GF2x64::pack(pack));
-
-        unsafe { transmute(packed_to_gf2x64) }
-    }
-
-    #[inline(always)]
-    fn unpack(&self) -> Vec<Self::Scalar> {
-        let packed_to_gf2x64: [GF2x64; Self::PACK_SIZE / GF2x64::PACK_SIZE] =
-            unsafe { transmute(*self) };
-
-        packed_to_gf2x64
-            .iter()
-            .flat_map(|packed| packed.unpack())
-            .collect()
     }
 }

--- a/arith/gf2/src/gf2x128/neon.rs
+++ b/arith/gf2/src/gf2x128/neon.rs
@@ -4,9 +4,9 @@ use std::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-use arith::{Field, FieldSerde, FieldSerdeResult, SimdField};
+use arith::{Field, FieldSerde, FieldSerdeResult};
 
-use crate::{GF2x64, GF2};
+use crate::GF2;
 
 #[derive(Clone, Copy, Debug)]
 pub struct NeonGF2x128 {
@@ -35,7 +35,7 @@ impl FieldSerde for NeonGF2x128 {
 }
 
 impl Field for NeonGF2x128 {
-    const NAME: &'static str = "Galios Field 2 SIMD 128";
+    const NAME: &'static str = "Neon Galois Field 2 SIMD 128";
 
     const SIZE: usize = 128 / 8;
 
@@ -301,43 +301,5 @@ impl From<GF2> for NeonGF2x128 {
         } else {
             NeonGF2x128::ONE
         }
-    }
-}
-
-impl SimdField for NeonGF2x128 {
-    type Scalar = GF2;
-
-    const PACK_SIZE: usize = 128;
-
-    #[inline(always)]
-    fn scale(&self, challenge: &Self::Scalar) -> Self {
-        if challenge.v == 0 {
-            Self::ZERO
-        } else {
-            *self
-        }
-    }
-
-    #[inline(always)]
-    fn pack(base_vec: &[Self::Scalar]) -> Self {
-        assert_eq!(base_vec.len(), Self::PACK_SIZE);
-        let mut packed_to_gf2x64 = [GF2x64::ZERO; Self::PACK_SIZE / GF2x64::PACK_SIZE];
-        packed_to_gf2x64
-            .iter_mut()
-            .zip(base_vec.chunks(GF2x64::PACK_SIZE))
-            .for_each(|(gf2x64, pack)| *gf2x64 = GF2x64::pack(pack));
-
-        unsafe { transmute(packed_to_gf2x64) }
-    }
-
-    #[inline(always)]
-    fn unpack(&self) -> Vec<Self::Scalar> {
-        let packed_to_gf2x64: [GF2x64; Self::PACK_SIZE / GF2x64::PACK_SIZE] =
-            unsafe { transmute(*self) };
-
-        packed_to_gf2x64
-            .iter()
-            .flat_map(|packed| packed.unpack())
-            .collect()
     }
 }

--- a/arith/gf2/src/gf2x8.rs
+++ b/arith/gf2/src/gf2x8.rs
@@ -30,7 +30,7 @@ impl FieldSerde for GF2x8 {
 impl Field for GF2x8 {
     // still will pack 8 bits into a u8
 
-    const NAME: &'static str = "Galios Field 2 SIMD 8";
+    const NAME: &'static str = "Galois Field 2 SIMD 8";
 
     const SIZE: usize = 1;
 
@@ -86,7 +86,7 @@ impl Field for GF2x8 {
 
     #[inline(always)]
     fn as_u32_unchecked(&self) -> u32 {
-        self.v as u32 % 256
+        self.v as u32
     }
 
     #[inline(always)]

--- a/arith/gf2_128/src/gf2_ext128/avx.rs
+++ b/arith/gf2_128/src/gf2_ext128/avx.rs
@@ -39,7 +39,7 @@ impl FieldSerde for AVXGF2_128 {
 }
 
 impl Field for AVXGF2_128 {
-    const NAME: &'static str = "Galios Field 2^128";
+    const NAME: &'static str = "AVX Galois Field 2^128";
 
     const SIZE: usize = 128 / 8;
 

--- a/arith/gf2_128/src/gf2_ext128/neon.rs
+++ b/arith/gf2_128/src/gf2_ext128/neon.rs
@@ -53,7 +53,7 @@ impl FieldSerde for NeonGF2_128 {
 }
 
 impl Field for NeonGF2_128 {
-    const NAME: &'static str = "Galios Field 2^128";
+    const NAME: &'static str = "Neon Galois Field 2^128";
 
     const SIZE: usize = 128 / 8;
 

--- a/arith/gf2_128/src/gf2_ext128x8/avx256.rs
+++ b/arith/gf2_128/src/gf2_ext128x8/avx256.rs
@@ -82,7 +82,7 @@ const PACKED_INV_2: [__m256i; 4] = [_M256_INV_2, _M256_INV_2, _M256_INV_2, _M256
 
 // p(x) = x^128 + x^7 + x^2 + x + 1
 impl Field for AVX256GF2_128x8 {
-    const NAME: &'static str = "AVX256 Galios Field 2^128";
+    const NAME: &'static str = "AVX256 Galois Field 2^128 SIMD 8";
 
     // size in bytes
     const SIZE: usize = 512 * 2 / 8;

--- a/arith/gf2_128/src/gf2_ext128x8/avx512.rs
+++ b/arith/gf2_128/src/gf2_ext128x8/avx512.rs
@@ -80,7 +80,7 @@ const PACKED_INV_2: [__m512i; 2] = [_M512_INV_2, _M512_INV_2]; // Should not be 
 
 // p(x) = x^128 + x^7 + x^2 + x + 1
 impl Field for AVX512GF2_128x8 {
-    const NAME: &'static str = "AVX512 Galios Field 2^128";
+    const NAME: &'static str = "AVX512 Galois Field 2^128 SIMD 8";
 
     // size in bytes
     const SIZE: usize = 512 * 2 / 8;
@@ -386,7 +386,7 @@ impl Debug for AVX512GF2_128x8 {
         let mut data = [0u8; 128];
         unsafe {
             _mm512_storeu_si512(data.as_mut_ptr() as *mut i32, self.data[0]);
-            _mm512_storeu_si512((data.as_mut_ptr() as *mut i32).offset(16), self.data[0]);
+            _mm512_storeu_si512((data.as_mut_ptr() as *mut i32).offset(16), self.data[1]);
         }
         f.debug_struct("AVX512GF2_128x8")
             .field("data", &data)

--- a/arith/gf2_128/src/gf2_ext128x8/neon.rs
+++ b/arith/gf2_128/src/gf2_ext128x8/neon.rs
@@ -55,7 +55,7 @@ impl FieldSerde for NeonGF2_128x8 {
 }
 
 impl Field for NeonGF2_128x8 {
-    const NAME: &'static str = "Neon Galios Field 2 128x8";
+    const NAME: &'static str = "Neon Galois Field 2^128 SIMD 8";
 
     const SIZE: usize = 16 * 8;
 

--- a/tree/Cargo.toml
+++ b/tree/Cargo.toml
@@ -17,7 +17,6 @@ rayon.workspace = true
 criterion.workspace = true
 gf2 = { path = "../arith/gf2" }
 gf2_128 = { path = "../arith/gf2_128" }
-mersenne31 = { path = "../arith/mersenne31" }
 tynm.workspace = true
 
 # p3-baby-bear.workspace = true

--- a/tree/benches/tree.rs
+++ b/tree/benches/tree.rs
@@ -1,10 +1,7 @@
-use std::time::Duration;
-
 use arith::{Field, SimdField};
 use ark_std::{rand::RngCore, test_rng};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use gf2::{GF2x128, GF2x64, GF2x8, GF2};
-use mersenne31::{M31x16, M31};
+use gf2::{GF2x128, GF2};
 use tree::{Leaf, Tree, LEAF_BYTES};
 use tynm::type_name;
 
@@ -33,8 +30,7 @@ fn tree_building_benchmark(c: &mut Criterion) {
                     Tree::new_with_leaves(leaves_benchmark.clone());
                 })
             })
-            .sample_size(10)
-            .measurement_time(Duration::from_secs(5));
+            .sample_size(10);
     }
 }
 
@@ -64,16 +60,12 @@ where
                     Tree::compact_new_with_field_elems::<F, PackF>(&field_elems_benchmark);
                 })
             })
-            .sample_size(10)
-            .measurement_time(Duration::from_secs(5));
+            .sample_size(10);
     }
 }
 
 fn compact_field_elem_tree_building_benchmark(c: &mut Criterion) {
-    compact_field_elem_tree_building_benchmark_generic::<GF2, GF2x8>(c);
-    compact_field_elem_tree_building_benchmark_generic::<GF2, GF2x64>(c);
     compact_field_elem_tree_building_benchmark_generic::<GF2, GF2x128>(c);
-    compact_field_elem_tree_building_benchmark_generic::<M31, M31x16>(c)
 }
 
 fn compact_packed_field_elem_tree_building_benchmark_generic<F, PackF>(c: &mut Criterion)
@@ -101,14 +93,12 @@ where
                     Tree::compact_new_with_packed_field_elems::<F, PackF>(&field_elems_benchmark);
                 })
             })
-            .sample_size(10)
-            .measurement_time(Duration::from_secs(5));
+            .sample_size(10);
     }
 }
 
 fn compact_packed_field_elem_tree_building_benchmark(c: &mut Criterion) {
-    compact_packed_field_elem_tree_building_benchmark_generic::<GF2, GF2x8>(c);
-    compact_packed_field_elem_tree_building_benchmark_generic::<GF2, GF2x64>(c);
+    compact_packed_field_elem_tree_building_benchmark_generic::<GF2, GF2x128>(c);
 }
 
 criterion_group!(


### PR DESCRIPTION
Separated from #137 before I rebase and realign the orion impl against new pcs trait