### PR TITLE
Minor: Traits for multilinear polynomials, PCS minor changes 

### DIFF
--- a/arith/polynomials/src/lib.rs
+++ b/arith/polynomials/src/lib.rs
@@ -1,6 +1,9 @@
 mod mle;
 pub use mle::*;
 
+mod ref_mle;
+pub use ref_mle::*;
+
 mod eq;
 pub use eq::*;
 

--- a/arith/polynomials/src/mle.rs
+++ b/arith/polynomials/src/mle.rs
@@ -102,12 +102,12 @@ impl<F: Field> MultiLinearPoly<F> {
 
     /// Evaluate the polynomial at the top variable
     #[inline]
-    pub fn fix_top_variable(&mut self, r: &F) {
+    pub fn fix_top_variable(&mut self, r: F) {
         let n = self.coeffs.len() / 2;
         let (left, right) = self.coeffs.split_at_mut(n);
 
         left.iter_mut().zip(right.iter()).for_each(|(a, b)| {
-            *a += *r * (*b - *a);
+            *a += r * (*b - *a);
         });
         self.coeffs.truncate(n);
     }
@@ -121,7 +121,7 @@ impl<F: Field> MultiLinearPoly<F> {
         partial_point
             .iter()
             .rev() // need to reverse the order of the point
-            .for_each(|point| self.fix_top_variable(point));
+            .for_each(|point| self.fix_top_variable(*point));
     }
 
     /// Jolt's implementation

--- a/arith/polynomials/src/mle.rs
+++ b/arith/polynomials/src/mle.rs
@@ -161,6 +161,10 @@ impl<F: Field> MultilinearExtension<F> for MultiLinearPoly<F> {
         self.coeffs.clone()
     }
 
+    fn hypercube_basis_ref(&self) -> &Vec<F> {
+        &self.coeffs
+    }
+
     fn evaluate_with_buffer(&self, point: &[F], scratch: &mut [F]) -> F {
         Self::evaluate_with_buffer(&self.coeffs, point, scratch)
     }

--- a/arith/polynomials/src/mle.rs
+++ b/arith/polynomials/src/mle.rs
@@ -1,7 +1,9 @@
+use std::ops::{Index, IndexMut, Mul};
+
 use arith::Field;
 use ark_std::{log2, rand::RngCore};
 
-use crate::EqPolynomial;
+use crate::{EqPolynomial, MultilinearExtension, MutableMultilinearExtension};
 
 #[derive(Debug, Clone, Default)]
 pub struct MultiLinearPoly<F: Field> {
@@ -102,7 +104,7 @@ impl<F: Field> MultiLinearPoly<F> {
 
     /// Evaluate the polynomial at the top variable
     #[inline]
-    pub fn fix_top_variable(&mut self, r: F) {
+    pub fn fix_top_variable<AF: Field + Mul<F, Output = F>>(&mut self, r: AF) {
         let n = self.coeffs.len() / 2;
         let (left, right) = self.coeffs.split_at_mut(n);
 
@@ -116,7 +118,7 @@ impl<F: Field> MultiLinearPoly<F> {
     /// Evaluate the polynomial at a set of variables, from bottom to top
     /// This is equivalent to `evaluate` when partial_point.len() = nv
     #[inline]
-    pub fn fix_variables(&mut self, partial_point: &[F]) {
+    pub fn fix_variables<AF: Field + Mul<F, Output = F>>(&mut self, partial_point: &[AF]) {
         // evaluate single variable of partial point from left to right
         partial_point
             .iter()
@@ -165,6 +167,64 @@ impl<F: Field> MultiLinearPoly<F> {
                 cur_eval_size >>= 1;
             }
             scratch[0]
+        }
+    }
+}
+
+impl<F: Field> Index<usize> for MultiLinearPoly<F> {
+    type Output = F;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.coeffs[index]
+    }
+}
+
+impl<F: Field> MultilinearExtension<F> for MultiLinearPoly<F> {
+    fn num_vars(&self) -> usize {
+        self.get_num_vars()
+    }
+
+    fn hypercube_basis(&self) -> Vec<F> {
+        self.coeffs.clone()
+    }
+
+    fn evaluate_with_buffer(&self, point: &[F], scratch: &mut [F]) -> F {
+        Self::evaluate_with_buffer(&self.coeffs, point, scratch)
+    }
+
+    fn interpolate_over_hypercube(&self) -> Vec<F> {
+        self.interpolate_over_hypercube()
+    }
+}
+
+impl<F: Field> IndexMut<usize> for MultiLinearPoly<F> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.coeffs[index]
+    }
+}
+
+impl<F: Field> MutableMultilinearExtension<F> for MultiLinearPoly<F> {
+    fn fix_top_variable<AF: Field + std::ops::Mul<F, Output = F>>(&mut self, r: AF) {
+        self.fix_top_variable(r)
+    }
+
+    fn fix_variables<AF: Field + std::ops::Mul<F, Output = F>>(&mut self, vars: &[AF]) {
+        self.fix_variables(vars)
+    }
+
+    fn interpolate_over_hypercube_in_place(&mut self) {
+        let num_vars = self.num_vars();
+        for i in 1..=num_vars {
+            let chunk_size = 1 << i;
+
+            self.coeffs.chunks_mut(chunk_size).for_each(|chunk| {
+                let half_chunk = chunk_size >> 1;
+                let (left, right) = chunk.split_at_mut(half_chunk);
+                right
+                    .iter_mut()
+                    .zip(left.iter())
+                    .for_each(|(a, b)| *a -= *b);
+            })
         }
     }
 }

--- a/arith/polynomials/src/mle.rs
+++ b/arith/polynomials/src/mle.rs
@@ -26,33 +26,6 @@ impl<F: Field> MultiLinearPoly<F> {
     }
 
     #[inline]
-    /// # Safety
-    /// The returned MultiLinearPoly should not be mutable in order not to
-    /// mess up the original vector
-    ///
-    /// PCS may take MultiLinearPoly as input
-    /// However, it is inefficient to copy the entire vector to create a new MultiLinearPoly
-    /// Here we introduce a wrap function to reuse the memory space assigned to the original vector
-    /// This is unsafe, and it is recommended to destroy the wrapper immediately after use
-    /// Example Usage:
-    ///
-    /// let vs = vec![F::ONE; 999999];
-    /// let mle_wrapper = MultiLinearPoly::<F>::wrap_around(&vs); // no extensive memory copy here
-    ///
-    /// // do something to mle
-    ///
-    /// mle_wrapper.wrapper_self_destroy() // please do not use drop here, it's incorrect
-    pub unsafe fn wrap_around(coeffs: &Vec<F>) -> Self {
-        Self {
-            coeffs: Vec::from_raw_parts(coeffs.as_ptr() as *mut F, coeffs.len(), coeffs.capacity()),
-        }
-    }
-
-    pub fn wrapper_self_detroy(self) {
-        self.coeffs.leak();
-    }
-
-    #[inline]
     pub fn get_num_vars(&self) -> usize {
         log2(self.coeffs.len()) as usize
     }

--- a/arith/polynomials/src/ref_mle.rs
+++ b/arith/polynomials/src/ref_mle.rs
@@ -1,0 +1,35 @@
+use arith::Field;
+
+use crate::MultiLinearPoly;
+
+#[derive(Debug, Clone)]
+pub struct RefMultiLinearPoly<'ref_life, F: Field> {
+    pub coeffs: &'ref_life [F],
+}
+
+impl<'ref_life, 'outer: 'ref_life, F: Field> RefMultiLinearPoly<'ref_life, F> {
+    #[inline]
+    pub fn from_ref(evals: &'outer [F]) -> Self {
+        Self { coeffs: evals }
+    }
+
+    pub fn evaluate_with_buffer(&self, point: &[F], scratch: &mut [F]) -> F {
+        MultiLinearPoly::evaluate_with_buffer(self.coeffs, point, scratch)
+    }
+}
+
+#[derive(Debug)]
+pub struct MutRefMultiLinearPoly<'ref_life, F: Field> {
+    pub coeffs: &'ref_life mut [F],
+}
+
+impl<'ref_life, 'outer_mut: 'ref_life, F: Field> MutRefMultiLinearPoly<'ref_life, F> {
+    #[inline]
+    pub fn from_ref(evals: &'outer_mut mut [F]) -> Self {
+        Self { coeffs: evals }
+    }
+
+    pub fn evaluate_with_buffer(&self, point: &[F], scratch: &mut [F]) -> F {
+        MultiLinearPoly::evaluate_with_buffer(self.coeffs, point, scratch)
+    }
+}

--- a/arith/polynomials/src/ref_mle.rs
+++ b/arith/polynomials/src/ref_mle.rs
@@ -15,6 +15,8 @@ pub trait MultilinearExtension<F: Field>: Index<usize, Output = F> {
 
     fn hypercube_basis(&self) -> Vec<F>;
 
+    fn hypercube_basis_ref(&self) -> &Vec<F>;
+
     fn interpolate_over_hypercube(&self) -> Vec<F>;
 }
 
@@ -47,6 +49,10 @@ impl<'a, F: Field> MultilinearExtension<F> for RefMultiLinearPoly<'a, F> {
 
     fn hypercube_basis(&self) -> Vec<F> {
         self.coeffs.clone()
+    }
+
+    fn hypercube_basis_ref(&self) -> &Vec<F> {
+        self.coeffs
     }
 
     fn interpolate_over_hypercube(&self) -> Vec<F> {
@@ -104,6 +110,10 @@ impl<'a, F: Field> MultilinearExtension<F> for MutRefMultiLinearPoly<'a, F> {
 
     fn hypercube_basis(&self) -> Vec<F> {
         self.coeffs.clone()
+    }
+
+    fn hypercube_basis_ref(&self) -> &Vec<F> {
+        self.coeffs
     }
 
     fn interpolate_over_hypercube(&self) -> Vec<F> {

--- a/arith/polynomials/src/ref_mle.rs
+++ b/arith/polynomials/src/ref_mle.rs
@@ -1,6 +1,22 @@
+use std::ops::{Index, IndexMut, Mul};
+
 use arith::Field;
 
 use crate::MultiLinearPoly;
+
+pub trait MultilinearExtension<F: Field>: Index<usize, Output = F> {
+    fn evaluate_with_buffer(&self, point: &[F], scratch: &mut [F]) -> F;
+
+    fn num_vars(&self) -> usize;
+
+    fn hypercube_size(&self) -> usize {
+        1 << self.num_vars()
+    }
+
+    fn hypercube_basis(&self) -> Vec<F>;
+
+    fn interpolate_over_hypercube(&self) -> Vec<F>;
+}
 
 #[derive(Debug, Clone)]
 pub struct RefMultiLinearPoly<'ref_life, F: Field> {
@@ -12,10 +28,44 @@ impl<'ref_life, 'outer: 'ref_life, F: Field> RefMultiLinearPoly<'ref_life, F> {
     pub fn from_ref(evals: &'outer Vec<F>) -> Self {
         Self { coeffs: evals }
     }
+}
 
-    pub fn evaluate_with_buffer(&self, point: &[F], scratch: &mut [F]) -> F {
+impl<'a, F: Field> Index<usize> for RefMultiLinearPoly<'a, F> {
+    type Output = F;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        assert!(index < self.hypercube_size());
+        &self.coeffs[index]
+    }
+}
+
+impl<'a, F: Field> MultilinearExtension<F> for RefMultiLinearPoly<'a, F> {
+    fn num_vars(&self) -> usize {
+        assert!(self.coeffs.len().is_power_of_two());
+        self.coeffs.len().ilog2() as usize
+    }
+
+    fn hypercube_basis(&self) -> Vec<F> {
+        self.coeffs.clone()
+    }
+
+    fn interpolate_over_hypercube(&self) -> Vec<F> {
+        MultiLinearPoly::interpolate_over_hypercube_impl(self.coeffs)
+    }
+
+    fn evaluate_with_buffer(&self, point: &[F], scratch: &mut [F]) -> F {
         MultiLinearPoly::evaluate_with_buffer(self.coeffs, point, scratch)
     }
+}
+
+pub trait MutableMultilinearExtension<F: Field>:
+    MultilinearExtension<F> + IndexMut<usize, Output = F>
+{
+    fn fix_top_variable<AF: Field + Mul<F, Output = F>>(&mut self, r: AF);
+
+    fn fix_variables<AF: Field + Mul<F, Output = F>>(&mut self, vars: &[AF]);
+
+    fn interpolate_over_hypercube_in_place(&mut self);
 }
 
 #[derive(Debug)]
@@ -28,26 +78,73 @@ impl<'ref_life, 'outer_mut: 'ref_life, F: Field> MutRefMultiLinearPoly<'ref_life
     pub fn from_ref(evals: &'outer_mut mut Vec<F>) -> Self {
         Self { coeffs: evals }
     }
+}
 
-    pub fn evaluate_with_buffer(&self, point: &[F], scratch: &mut [F]) -> F {
-        MultiLinearPoly::evaluate_with_buffer(self.coeffs, point, scratch)
+impl<'a, F: Field> Index<usize> for MutRefMultiLinearPoly<'a, F> {
+    type Output = F;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        assert!(index < self.hypercube_size());
+        &self.coeffs[index]
+    }
+}
+
+impl<'a, F: Field> IndexMut<usize> for MutRefMultiLinearPoly<'a, F> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        assert!(index < self.hypercube_size());
+        &mut self.coeffs[index]
+    }
+}
+
+impl<'a, F: Field> MultilinearExtension<F> for MutRefMultiLinearPoly<'a, F> {
+    fn num_vars(&self) -> usize {
+        assert!(self.coeffs.len().is_power_of_two());
+        self.coeffs.len().ilog2() as usize
     }
 
-    pub fn fix_top_variable(&mut self, r: F) {
-        let n = self.coeffs.len() / 2;
+    fn hypercube_basis(&self) -> Vec<F> {
+        self.coeffs.clone()
+    }
+
+    fn interpolate_over_hypercube(&self) -> Vec<F> {
+        MultiLinearPoly::interpolate_over_hypercube_impl(self.coeffs)
+    }
+
+    fn evaluate_with_buffer(&self, point: &[F], scratch: &mut [F]) -> F {
+        MultiLinearPoly::evaluate_with_buffer(self.coeffs, point, scratch)
+    }
+}
+
+impl<'a, F: Field> MutableMultilinearExtension<F> for MutRefMultiLinearPoly<'a, F> {
+    fn fix_top_variable<AF: Field + Mul<F, Output = F>>(&mut self, r: AF) {
+        let n = self.hypercube_size() / 2;
         let (left, right) = self.coeffs.split_at_mut(n);
 
         left.iter_mut().zip(right.iter()).for_each(|(a, b)| {
             *a += r * (*b - *a);
         });
-        self.coeffs.truncate(n);
+        self.coeffs.truncate(n)
     }
 
-    pub fn fix_variables(&mut self, partial_point: &[F]) {
+    fn fix_variables<AF: Field + Mul<F, Output = F>>(&mut self, vars: &[AF]) {
         // evaluate single variable of partial point from left to right
-        partial_point
-            .iter()
-            .rev() // need to reverse the order of the point
-            .for_each(|point| self.fix_top_variable(*point));
+        // need to reverse the order of the point
+        vars.iter().rev().for_each(|p| self.fix_top_variable(*p))
+    }
+
+    fn interpolate_over_hypercube_in_place(&mut self) {
+        let num_vars = self.num_vars();
+        for i in 1..=num_vars {
+            let chunk_size = 1 << i;
+
+            self.coeffs.chunks_mut(chunk_size).for_each(|chunk| {
+                let half_chunk = chunk_size >> 1;
+                let (left, right) = chunk.split_at_mut(half_chunk);
+                right
+                    .iter_mut()
+                    .zip(left.iter())
+                    .for_each(|(a, b)| *a -= *b);
+            })
+        }
     }
 }

--- a/arith/polynomials/src/ref_mle.rs
+++ b/arith/polynomials/src/ref_mle.rs
@@ -4,12 +4,12 @@ use crate::MultiLinearPoly;
 
 #[derive(Debug, Clone)]
 pub struct RefMultiLinearPoly<'ref_life, F: Field> {
-    pub coeffs: &'ref_life [F],
+    pub coeffs: &'ref_life Vec<F>,
 }
 
 impl<'ref_life, 'outer: 'ref_life, F: Field> RefMultiLinearPoly<'ref_life, F> {
     #[inline]
-    pub fn from_ref(evals: &'outer [F]) -> Self {
+    pub fn from_ref(evals: &'outer Vec<F>) -> Self {
         Self { coeffs: evals }
     }
 
@@ -20,16 +20,34 @@ impl<'ref_life, 'outer: 'ref_life, F: Field> RefMultiLinearPoly<'ref_life, F> {
 
 #[derive(Debug)]
 pub struct MutRefMultiLinearPoly<'ref_life, F: Field> {
-    pub coeffs: &'ref_life mut [F],
+    pub coeffs: &'ref_life mut Vec<F>,
 }
 
 impl<'ref_life, 'outer_mut: 'ref_life, F: Field> MutRefMultiLinearPoly<'ref_life, F> {
     #[inline]
-    pub fn from_ref(evals: &'outer_mut mut [F]) -> Self {
+    pub fn from_ref(evals: &'outer_mut mut Vec<F>) -> Self {
         Self { coeffs: evals }
     }
 
     pub fn evaluate_with_buffer(&self, point: &[F], scratch: &mut [F]) -> F {
         MultiLinearPoly::evaluate_with_buffer(self.coeffs, point, scratch)
+    }
+
+    pub fn fix_top_variable(&mut self, r: F) {
+        let n = self.coeffs.len() / 2;
+        let (left, right) = self.coeffs.split_at_mut(n);
+
+        left.iter_mut().zip(right.iter()).for_each(|(a, b)| {
+            *a += r * (*b - *a);
+        });
+        self.coeffs.truncate(n);
+    }
+
+    pub fn fix_variables(&mut self, partial_point: &[F]) {
+        // evaluate single variable of partial point from left to right
+        partial_point
+            .iter()
+            .rev() // need to reverse the order of the point
+            .for_each(|point| self.fix_top_variable(*point));
     }
 }

--- a/arith/polynomials/src/tests.rs
+++ b/arith/polynomials/src/tests.rs
@@ -74,6 +74,28 @@ fn test_eq_xr() {
     }
 }
 
+#[test]
+fn test_ref_multilinear_poly() {
+    let mut rng = test_rng();
+    for nv in 4..=10 {
+        let es_len = 1 << nv;
+        let es: Vec<Fr> = (0..es_len).map(|_| Fr::random_unsafe(&mut rng)).collect();
+        let point: Vec<Fr> = (0..nv).map(|_| Fr::random_unsafe(&mut rng)).collect();
+        let mut scratch = vec![Fr::ZERO; es_len];
+
+        let mle_from_ref = RefMultiLinearPoly::<Fr>::from_ref(&es);
+
+        let actual_eval = mle_from_ref.evaluate_with_buffer(&point, &mut scratch);
+        let expect_eval = MultiLinearPoly::evaluate_with_buffer(&es, &point, &mut scratch);
+
+        drop(mle_from_ref);
+
+        assert_eq!(actual_eval, expect_eval);
+
+        drop(es);
+    }
+}
+
 /// Naive method to build eq(x, r).
 /// Only used for testing purpose.
 // Evaluate

--- a/arith/polynomials/src/tests.rs
+++ b/arith/polynomials/src/tests.rs
@@ -96,6 +96,29 @@ fn test_ref_multilinear_poly() {
     }
 }
 
+#[test]
+fn test_mut_ref_multilinear_poly() {
+    let mut rng = test_rng();
+    for nv in 4..=10 {
+        let es_len = 1 << nv;
+        let mut es: Vec<Fr> = (0..es_len).map(|_| Fr::random_unsafe(&mut rng)).collect();
+        let es_cloned = es.clone();
+        let point: Vec<Fr> = (0..nv).map(|_| Fr::random_unsafe(&mut rng)).collect();
+        let mut scratch = vec![Fr::ZERO; es_len];
+
+        let mut mle_from_mut_ref = MutRefMultiLinearPoly::<Fr>::from_ref(&mut es);
+
+        mle_from_mut_ref.fix_variables(&point);
+        let expect_eval = MultiLinearPoly::evaluate_with_buffer(&es_cloned, &point, &mut scratch);
+
+        drop(mle_from_mut_ref);
+
+        assert_eq!(es[0], expect_eval);
+
+        drop(es);
+    }
+}
+
 /// Naive method to build eq(x, r).
 /// Only used for testing purpose.
 // Evaluate

--- a/gkr/src/prover/linear_gkr.rs
+++ b/gkr/src/prover/linear_gkr.rs
@@ -6,7 +6,7 @@ use circuit::Circuit;
 use config::{Config, GKRConfig, GKRScheme};
 use gkr_field_config::GKRFieldConfig;
 use poly_commit::{ExpanderGKRChallenge, PCSForExpanderGKR, StructuredReferenceString};
-use polynomials::MultiLinearPoly;
+use polynomials::{MultilinearExtension, RefMultiLinearPoly};
 use sumcheck::ProverScratchPad;
 use transcript::{transcript_root_broadcast, Proof, Transcript};
 
@@ -87,18 +87,19 @@ impl<Cfg: GKRConfig> Prover<Cfg> {
         let mut transcript = Cfg::Transcript::new();
 
         // PC commit
-        let mle_wrapper = unsafe { MultiLinearPoly::wrap_around(&c.layers[0].input_vals) };
-        let commitment = Cfg::PCS::commit(
-            pcs_params,
-            &self.config.mpi_config,
-            pcs_proving_key,
-            &mle_wrapper,
-            pcs_scratch,
-        );
+        let commitment = {
+            let mle_ref = RefMultiLinearPoly::from_ref(&c.layers[0].input_vals);
+            Cfg::PCS::commit(
+                pcs_params,
+                &self.config.mpi_config,
+                pcs_proving_key,
+                &mle_ref,
+                pcs_scratch,
+            )
+        };
         let mut buffer = vec![];
         commitment.serialize_into(&mut buffer).unwrap(); // TODO: error propagation
         transcript.append_u8_slice(&buffer);
-        mle_wrapper.wrapper_self_detroy();
 
         transcript_root_broadcast(&mut transcript, &self.config.mpi_config);
 
@@ -121,10 +122,10 @@ impl<Cfg: GKRConfig> Prover<Cfg> {
                 gkr_prove(c, &mut self.sp, &mut transcript, &self.config.mpi_config);
         }
 
-        let mle_wrapper = unsafe { MultiLinearPoly::wrap_around(&c.layers[0].input_vals) };
         // open
+        let mle_ref = RefMultiLinearPoly::from_ref(&c.layers[0].input_vals);
         self.prove_input_layer_claim(
-            &mle_wrapper,
+            &mle_ref,
             &ExpanderGKRChallenge {
                 x: rx,
                 x_simd: rsimd.clone(),
@@ -138,7 +139,7 @@ impl<Cfg: GKRConfig> Prover<Cfg> {
 
         if let Some(ry) = ry {
             self.prove_input_layer_claim(
-                &mle_wrapper,
+                &mle_ref,
                 &ExpanderGKRChallenge {
                     x: ry,
                     x_simd: rsimd,
@@ -150,7 +151,6 @@ impl<Cfg: GKRConfig> Prover<Cfg> {
                 &mut transcript,
             );
         }
-        mle_wrapper.wrapper_self_detroy();
 
         end_timer!(timer);
 
@@ -161,7 +161,9 @@ impl<Cfg: GKRConfig> Prover<Cfg> {
 impl<Cfg: GKRConfig> Prover<Cfg> {
     fn prove_input_layer_claim(
         &self,
-        input_layer_mle: &MultiLinearPoly<<Cfg::FieldConfig as GKRFieldConfig>::SimdCircuitField>,
+        inputs: &'_ dyn MultilinearExtension<
+            <Cfg::FieldConfig as GKRFieldConfig>::SimdCircuitField,
+        >,
         open_at: &ExpanderGKRChallenge<Cfg::FieldConfig>,
         pcs_params: &<Cfg::PCS as PCSForExpanderGKR<Cfg::FieldConfig, Cfg::Transcript>>::Params,
         pcs_proving_key: &<<Cfg::PCS as PCSForExpanderGKR<Cfg::FieldConfig, Cfg::Transcript>>::SRS as StructuredReferenceString>::PKey,
@@ -172,7 +174,7 @@ impl<Cfg: GKRConfig> Prover<Cfg> {
             pcs_params,
             &self.config.mpi_config,
             pcs_proving_key,
-            input_layer_mle,
+            inputs,
             open_at,
             transcript,
             pcs_scratch,

--- a/gkr/src/prover/linear_gkr.rs
+++ b/gkr/src/prover/linear_gkr.rs
@@ -161,9 +161,7 @@ impl<Cfg: GKRConfig> Prover<Cfg> {
 impl<Cfg: GKRConfig> Prover<Cfg> {
     fn prove_input_layer_claim(
         &self,
-        inputs: &'_ dyn MultilinearExtension<
-            <Cfg::FieldConfig as GKRFieldConfig>::SimdCircuitField,
-        >,
+        inputs: &impl MultilinearExtension<<Cfg::FieldConfig as GKRFieldConfig>::SimdCircuitField>,
         open_at: &ExpanderGKRChallenge<Cfg::FieldConfig>,
         pcs_params: &<Cfg::PCS as PCSForExpanderGKR<Cfg::FieldConfig, Cfg::Transcript>>::Params,
         pcs_proving_key: &<<Cfg::PCS as PCSForExpanderGKR<Cfg::FieldConfig, Cfg::Transcript>>::SRS as StructuredReferenceString>::PKey,

--- a/poly_commit/src/raw.rs
+++ b/poly_commit/src/raw.rs
@@ -165,7 +165,7 @@ impl<C: GKRFieldConfig, T: Transcript<C::ChallengeField>> PCSForExpanderGKR<C, T
                 vec![]
             };
 
-            mpi_config.gather_vec(&poly.hypercube_basis(), &mut buffer);
+            mpi_config.gather_vec(poly.hypercube_basis_ref(), &mut buffer);
             buffer
         }
     }

--- a/poly_commit/src/raw.rs
+++ b/poly_commit/src/raw.rs
@@ -152,7 +152,7 @@ impl<C: GKRFieldConfig, T: Transcript<C::ChallengeField>> PCSForExpanderGKR<C, T
         params: &Self::Params,
         mpi_config: &MPIConfig,
         _proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
-        poly: &'_ dyn MultilinearExtension<C::SimdCircuitField>,
+        poly: &impl MultilinearExtension<C::SimdCircuitField>,
         _scratch_pad: &mut Self::ScratchPad,
     ) -> Self::Commitment {
         assert!(poly.num_vars() == params.n_local_vars);
@@ -174,7 +174,7 @@ impl<C: GKRFieldConfig, T: Transcript<C::ChallengeField>> PCSForExpanderGKR<C, T
         _params: &Self::Params,
         _mpi_config: &MPIConfig,
         _proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
-        _poly: &'_ dyn MultilinearExtension<C::SimdCircuitField>,
+        _poly: &impl MultilinearExtension<C::SimdCircuitField>,
         _x: &ExpanderGKRChallenge<C>,
         _transcript: &mut T,
         _scratch_pad: &mut Self::ScratchPad,

--- a/poly_commit/src/raw.rs
+++ b/poly_commit/src/raw.rs
@@ -6,7 +6,7 @@ use crate::{
 use arith::{Field, SimdField};
 use gkr_field_config::GKRFieldConfig;
 use mpi_config::MPIConfig;
-use polynomials::MultiLinearPoly;
+use polynomials::{MultiLinearPoly, MultilinearExtension};
 use rand::RngCore;
 use transcript::Transcript;
 
@@ -152,20 +152,20 @@ impl<C: GKRFieldConfig, T: Transcript<C::ChallengeField>> PCSForExpanderGKR<C, T
         params: &Self::Params,
         mpi_config: &MPIConfig,
         _proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
-        poly: &MultiLinearPoly<C::SimdCircuitField>,
+        poly: &'_ dyn MultilinearExtension<C::SimdCircuitField>,
         _scratch_pad: &mut Self::ScratchPad,
     ) -> Self::Commitment {
-        assert!(poly.coeffs.len() == 1 << params.n_local_vars);
+        assert!(poly.num_vars() == params.n_local_vars);
         if mpi_config.world_size() == 1 {
-            poly.coeffs.clone()
+            poly.hypercube_basis()
         } else {
             let mut buffer = if mpi_config.is_root() {
-                vec![C::SimdCircuitField::zero(); poly.coeffs.len() * mpi_config.world_size()]
+                vec![C::SimdCircuitField::zero(); poly.hypercube_size() * mpi_config.world_size()]
             } else {
                 vec![]
             };
 
-            mpi_config.gather_vec(&poly.coeffs, &mut buffer);
+            mpi_config.gather_vec(&poly.hypercube_basis(), &mut buffer);
             buffer
         }
     }
@@ -174,7 +174,7 @@ impl<C: GKRFieldConfig, T: Transcript<C::ChallengeField>> PCSForExpanderGKR<C, T
         _params: &Self::Params,
         _mpi_config: &MPIConfig,
         _proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
-        _poly: &MultiLinearPoly<C::SimdCircuitField>,
+        _poly: &'_ dyn MultilinearExtension<C::SimdCircuitField>,
         _x: &ExpanderGKRChallenge<C>,
         _transcript: &mut T,
         _scratch_pad: &mut Self::ScratchPad,

--- a/poly_commit/src/traits.rs
+++ b/poly_commit/src/traits.rs
@@ -1,7 +1,7 @@
 use arith::{Field, FieldSerde};
 use gkr_field_config::GKRFieldConfig;
 use mpi_config::MPIConfig;
-use polynomials::MultiLinearPoly;
+use polynomials::MultilinearExtension;
 use rand::RngCore;
 use std::fmt::Debug;
 use transcript::Transcript;
@@ -99,7 +99,7 @@ pub trait PCSForExpanderGKR<C: GKRFieldConfig, T: Transcript<C::ChallengeField>>
         params: &Self::Params,
         mpi_config: &MPIConfig,
         proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
-        poly: &MultiLinearPoly<C::SimdCircuitField>,
+        poly: &'_ dyn MultilinearExtension<C::SimdCircuitField>,
         scratch_pad: &mut Self::ScratchPad,
     ) -> Self::Commitment;
 
@@ -123,7 +123,7 @@ pub trait PCSForExpanderGKR<C: GKRFieldConfig, T: Transcript<C::ChallengeField>>
         params: &Self::Params,
         mpi_config: &MPIConfig,
         proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
-        poly: &MultiLinearPoly<C::SimdCircuitField>,
+        poly: &'_ dyn MultilinearExtension<C::SimdCircuitField>,
         x: &ExpanderGKRChallenge<C>,
         transcript: &mut T, // add transcript here to allow interactive arguments
         scratch_pad: &mut Self::ScratchPad,

--- a/poly_commit/src/traits.rs
+++ b/poly_commit/src/traits.rs
@@ -99,7 +99,7 @@ pub trait PCSForExpanderGKR<C: GKRFieldConfig, T: Transcript<C::ChallengeField>>
         params: &Self::Params,
         mpi_config: &MPIConfig,
         proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
-        poly: &'_ dyn MultilinearExtension<C::SimdCircuitField>,
+        poly: &impl MultilinearExtension<C::SimdCircuitField>,
         scratch_pad: &mut Self::ScratchPad,
     ) -> Self::Commitment;
 
@@ -123,7 +123,7 @@ pub trait PCSForExpanderGKR<C: GKRFieldConfig, T: Transcript<C::ChallengeField>>
         params: &Self::Params,
         mpi_config: &MPIConfig,
         proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
-        poly: &'_ dyn MultilinearExtension<C::SimdCircuitField>,
+        poly: &impl MultilinearExtension<C::SimdCircuitField>,
         x: &ExpanderGKRChallenge<C>,
         transcript: &mut T, // add transcript here to allow interactive arguments
         scratch_pad: &mut Self::ScratchPad,

--- a/poly_commit/tests/common.rs
+++ b/poly_commit/tests/common.rs
@@ -42,7 +42,7 @@ pub fn test_gkr_pcs<
     params: &P::Params,
     mpi_config: &MPIConfig,
     transcript: &mut T,
-    poly: &'_ dyn MultilinearExtension<C::SimdCircuitField>,
+    poly: &impl MultilinearExtension<C::SimdCircuitField>,
     xs: &[ExpanderGKRChallenge<C>],
 ) {
     let mut rng = thread_rng();

--- a/poly_commit/tests/common.rs
+++ b/poly_commit/tests/common.rs
@@ -60,7 +60,7 @@ pub fn test_gkr_pcs<
     } else {
         vec![]
     };
-    mpi_config.gather_vec(&poly.hypercube_basis(), &mut coeffs_gathered);
+    mpi_config.gather_vec(poly.hypercube_basis_ref(), &mut coeffs_gathered);
 
     for xx in xs {
         let ExpanderGKRChallenge { x, x_simd, x_mpi } = xx;

--- a/poly_commit/tests/common.rs
+++ b/poly_commit/tests/common.rs
@@ -5,7 +5,7 @@ use poly_commit::raw::RawExpanderGKR;
 use poly_commit::{
     ExpanderGKRChallenge, PCSForExpanderGKR, PolynomialCommitmentScheme, StructuredReferenceString,
 };
-use polynomials::MultiLinearPoly;
+use polynomials::MultilinearExtension;
 use rand::thread_rng;
 use transcript::Transcript;
 
@@ -42,7 +42,7 @@ pub fn test_gkr_pcs<
     params: &P::Params,
     mpi_config: &MPIConfig,
     transcript: &mut T,
-    poly: &MultiLinearPoly<C::SimdCircuitField>,
+    poly: &'_ dyn MultilinearExtension<C::SimdCircuitField>,
     xs: &[ExpanderGKRChallenge<C>],
 ) {
     let mut rng = thread_rng();
@@ -56,11 +56,11 @@ pub fn test_gkr_pcs<
     // We use RawExpanderGKR as the golden standard for the evaluation value
     // Note this test will almost always pass for RawExpanderGKR, so make sure it is correct
     let mut coeffs_gathered = if mpi_config.is_root() {
-        vec![C::SimdCircuitField::ZERO; poly.coeffs.len() * mpi_config.world_size()]
+        vec![C::SimdCircuitField::ZERO; poly.hypercube_size() * mpi_config.world_size()]
     } else {
         vec![]
     };
-    mpi_config.gather_vec(&poly.coeffs, &mut coeffs_gathered);
+    mpi_config.gather_vec(&poly.hypercube_basis(), &mut coeffs_gathered);
 
     for xx in xs {
         let ExpanderGKRChallenge { x, x_simd, x_mpi } = xx;

--- a/poly_commit/tests/test_raw.rs
+++ b/poly_commit/tests/test_raw.rs
@@ -7,7 +7,7 @@ use poly_commit::{
     raw::{RawExpanderGKR, RawExpanderGKRParams, RawMultiLinear, RawMultiLinearParams},
     ExpanderGKRChallenge,
 };
-use polynomials::MultiLinearPoly;
+use polynomials::{MultiLinearPoly, RefMultiLinearPoly};
 use rand::thread_rng;
 use transcript::{BytesHashTranscript, SHA256hasher, Transcript};
 
@@ -33,7 +33,10 @@ fn test_raw_gkr_helper<C: GKRFieldConfig, T: Transcript<C::ChallengeField>>(
 ) {
     let params = RawExpanderGKRParams { n_local_vars: 8 };
     let mut rng = thread_rng();
-    let poly = MultiLinearPoly::<C::SimdCircuitField>::random(params.n_local_vars, &mut rng);
+    let hypercube_basis = (0..(1 << params.n_local_vars))
+        .map(|_| C::SimdCircuitField::random_unsafe(&mut rng))
+        .collect();
+    let poly = RefMultiLinearPoly::from_ref(&hypercube_basis);
     let xs = (0..100)
         .map(|_| ExpanderGKRChallenge::<C> {
             x: (0..params.n_local_vars)


### PR DESCRIPTION
This PR is motivated by a short discussion with ZF after #150 .

Eventually, we want to avoid the explicit call to `wrap_around` and `wrapper_self_destroy`, and we might want to pass in an object implemented certain traits tied to multilinear polynomials into various PCS implementations.

Thus, this PR includes following changes:
- Introducing `MultilinearExtension` and `MutableMultilinearExtension` traits
- Introducing `RefMultilinearPoly` and `MutRefMultilinearPoly` that builds from a slice of field elements as MLE hypercube basis.
- PCS trait commit/open accepting `&_ dyn MultilinearExtension<_>` object to cater distinct instantiations for MLE polys (either direct instance of `MultiLinearPoly`, or `(Mut)RefMultiLinearPoly`.