### PR TITLE
Minor: PCS CRS from external rng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,7 @@ dependencies = [
  "poly_commit",
  "polynomials",
  "rand",
+ "rand_chacha",
  "sha2",
  "sumcheck",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ members = [
 ]
 resolver = "2"
 
-
 [workspace.dependencies]
 ark-std = "0.4"
 ark-bn254 = "0.4.0"
@@ -46,3 +45,4 @@ tynm = { version = "0.1.6", default-features = false }
 warp = "0.3.7"
 thiserror = "1.0.63"
 ethnum = "1.5.0"
+rand_chacha = "0.3.1"

--- a/gkr/Cargo.toml
+++ b/gkr/Cargo.toml
@@ -28,6 +28,7 @@ sha2.workspace = true
 halo2curves.workspace = true
 thiserror.workspace = true
 ethnum.workspace = true
+rand_chacha.workspace = true
 
 # for the server
 bytes.workspace = true

--- a/gkr/benches/gkr_hashes.rs
+++ b/gkr/benches/gkr_hashes.rs
@@ -15,6 +15,7 @@ use poly_commit::{
     expander_pcs_init_testing_only, raw::RawExpanderGKR, PCSForExpanderGKR,
     StructuredReferenceString,
 };
+use rand::thread_rng;
 use std::hint::black_box;
 use transcript::{BytesHashTranscript, SHA256hasher};
 
@@ -55,10 +56,12 @@ fn benchmark_setup<Cfg: GKRConfig>(
         circuit.set_random_input_for_test();
     }
 
+    let mut rng = thread_rng();
     let (pcs_params, pcs_proving_key, _pcs_verification_key, pcs_scratch) =
         expander_pcs_init_testing_only::<Cfg::FieldConfig, Cfg::Transcript, Cfg::PCS>(
             circuit.log_input_size(),
             &config.mpi_config,
+            &mut rng,
         );
 
     (config, circuit, pcs_params, pcs_proving_key, pcs_scratch)

--- a/gkr/src/main.rs
+++ b/gkr/src/main.rs
@@ -11,6 +11,8 @@ use gkr_field_config::{BN254Config, GF2ExtConfig, GKRFieldConfig, M31ExtConfig};
 use mpi_config::MPIConfig;
 
 use poly_commit::{expander_pcs_init_testing_only, raw::RawExpanderGKR};
+use rand::SeedableRng;
+use rand_chacha::ChaCha12Rng;
 use transcript::{BytesHashTranscript, SHA256hasher};
 
 use gkr::{
@@ -113,6 +115,8 @@ fn main() {
     MPIConfig::finalize();
 }
 
+const PCS_TESTING_SEED_U64: u64 = 114514;
+
 fn run_benchmark<Cfg: GKRConfig>(args: &Args, config: Config<Cfg>) {
     let partial_proof_cnts = (0..args.threads)
         .map(|_| Arc::new(Mutex::new(0)))
@@ -175,10 +179,12 @@ fn run_benchmark<Cfg: GKRConfig>(args: &Args, config: Config<Cfg>) {
 
     println!("Circuit loaded!");
 
+    let mut rng = ChaCha12Rng::seed_from_u64(PCS_TESTING_SEED_U64);
     let (pcs_params, pcs_proving_key, _pcs_verification_key, pcs_scratch) =
         expander_pcs_init_testing_only::<Cfg::FieldConfig, Cfg::Transcript, Cfg::PCS>(
             circuit_template.log_input_size(),
             &config.mpi_config,
+            &mut rng,
         );
 
     let start_time = std::time::Instant::now();

--- a/gkr/src/main_mpi.rs
+++ b/gkr/src/main_mpi.rs
@@ -6,6 +6,8 @@ use mpi_config::MPIConfig;
 
 use gkr_field_config::{BN254Config, GF2ExtConfig, GKRFieldConfig, M31ExtConfig};
 use poly_commit::{expander_pcs_init_testing_only, raw::RawExpanderGKR};
+use rand::SeedableRng;
+use rand_chacha::ChaCha12Rng;
 use transcript::{BytesHashTranscript, SHA256hasher};
 
 use gkr::{
@@ -104,6 +106,8 @@ fn main() {
     MPIConfig::finalize();
 }
 
+const PCS_TESTING_SEED_U64: u64 = 114514;
+
 fn run_benchmark<Cfg: GKRConfig>(args: &Args, config: Config<Cfg>) {
     let pack_size = Cfg::FieldConfig::get_field_pack_size();
 
@@ -154,10 +158,13 @@ fn run_benchmark<Cfg: GKRConfig>(args: &Args, config: Config<Cfg>) {
 
     let mut prover = Prover::new(&config);
     prover.prepare_mem(&circuit);
+
+    let mut rng = ChaCha12Rng::seed_from_u64(PCS_TESTING_SEED_U64);
     let (pcs_params, pcs_proving_key, _pcs_verification_key, mut pcs_scratch) =
         expander_pcs_init_testing_only::<Cfg::FieldConfig, Cfg::Transcript, Cfg::PCS>(
             circuit.log_input_size(),
             &config.mpi_config,
+            &mut rng,
         );
 
     const N_PROOF: usize = 1000;

--- a/gkr/src/prover/linear_gkr.rs
+++ b/gkr/src/prover/linear_gkr.rs
@@ -168,6 +168,7 @@ impl<Cfg: GKRConfig> Prover<Cfg> {
         pcs_scratch: &mut <Cfg::PCS as PCSForExpanderGKR<Cfg::FieldConfig, Cfg::Transcript>>::ScratchPad,
         transcript: &mut Cfg::Transcript,
     ) {
+        transcript.lock_proof();
         let opening = Cfg::PCS::open(
             pcs_params,
             &self.config.mpi_config,
@@ -177,6 +178,8 @@ impl<Cfg: GKRConfig> Prover<Cfg> {
             transcript,
             pcs_scratch,
         );
+        transcript.unlock_proof();
+
         let mut buffer = vec![];
         opening.serialize_into(&mut buffer).unwrap(); // TODO: error propagation
         transcript.append_u8_slice(&buffer);

--- a/gkr/src/tests/gkr_correctness.rs
+++ b/gkr/src/tests/gkr_correctness.rs
@@ -11,13 +11,16 @@ use gkr_field_config::{BN254Config, FieldType, GF2ExtConfig, GKRFieldConfig, M31
 use mpi_config::{root_println, MPIConfig};
 use poly_commit::expander_pcs_init_testing_only;
 use poly_commit::raw::RawExpanderGKR;
-use rand::Rng;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha12Rng;
 use sha2::Digest;
 use transcript::{
     BytesHashTranscript, FieldHashTranscript, Keccak256hasher, MIMCHasher, SHA256hasher,
 };
 
 use crate::{utils::*, Prover, Verifier};
+
+const PCS_TESTING_SEED_U64: u64 = 114514;
 
 #[test]
 fn test_gkr_correctness() {
@@ -145,10 +148,12 @@ fn test_gkr_correctness_helper<Cfg: GKRConfig>(config: &Config<Cfg>, write_proof
     let mut prover = Prover::new(config);
     prover.prepare_mem(&circuit);
 
+    let mut rng = ChaCha12Rng::seed_from_u64(PCS_TESTING_SEED_U64);
     let (pcs_params, pcs_proving_key, pcs_verification_key, mut pcs_scratch) =
         expander_pcs_init_testing_only::<Cfg::FieldConfig, Cfg::Transcript, Cfg::PCS>(
             circuit.log_input_size(),
             &config.mpi_config,
+            &mut rng,
         );
 
     let proving_start = Instant::now();

--- a/gkr/src/verifier.rs
+++ b/gkr/src/verifier.rs
@@ -360,6 +360,7 @@ impl<Cfg: GKRConfig> Verifier<Cfg> {
         )
         .unwrap();
 
+        transcript.lock_proof();
         let verified = Cfg::PCS::verify(
             pcs_params,
             &self.config.mpi_config,
@@ -370,6 +371,7 @@ impl<Cfg: GKRConfig> Verifier<Cfg> {
             transcript,
             &opening,
         );
+        transcript.unlock_proof();
 
         let mut buffer = vec![];
         opening.serialize_into(&mut buffer).unwrap(); // TODO: error propagation

--- a/poly_commit/src/lib.rs
+++ b/poly_commit/src/lib.rs
@@ -1,46 +1,9 @@
 mod traits;
-use gkr_field_config::GKRFieldConfig;
-use mpi_config::MPIConfig;
-use rand::thread_rng;
 pub use traits::{
     ExpanderGKRChallenge, PCSForExpanderGKR, PolynomialCommitmentScheme, StructuredReferenceString,
 };
 
-#[allow(clippy::type_complexity)]
-pub fn expander_pcs_init_testing_only<
-    FieldConfig: GKRFieldConfig,
-    T: Transcript<FieldConfig::ChallengeField>,
-    PCS: PCSForExpanderGKR<FieldConfig, T>,
->(
-    n_input_vars: usize,
-    mpi_config: &MPIConfig,
-) -> (
-    PCS::Params,
-    <PCS::SRS as StructuredReferenceString>::PKey,
-    <PCS::SRS as StructuredReferenceString>::VKey,
-    PCS::ScratchPad,
-) {
-    let mut rng = thread_rng();
-    let pcs_params = <PCS as PCSForExpanderGKR<FieldConfig, T>>::gen_params(n_input_vars);
-    let pcs_setup = <PCS as PCSForExpanderGKR<FieldConfig, T>>::gen_srs_for_testing(
-        &pcs_params,
-        mpi_config,
-        &mut rng,
-    );
-    let (pcs_proving_key, pcs_verification_key) = pcs_setup.into_keys();
-    let pcs_scratch =
-        <PCS as PCSForExpanderGKR<FieldConfig, T>>::init_scratch_pad(&pcs_params, mpi_config);
-
-    (
-        pcs_params,
-        pcs_proving_key,
-        pcs_verification_key,
-        pcs_scratch,
-    )
-}
-
 mod utils;
-use transcript::Transcript;
-use utils::PCSEmptyType;
+pub use utils::{expander_pcs_init_testing_only, PCSEmptyType};
 
 pub mod raw;

--- a/poly_commit/src/utils.rs
+++ b/poly_commit/src/utils.rs
@@ -1,5 +1,9 @@
-use crate::StructuredReferenceString;
 use arith::FieldSerde;
+use gkr_field_config::GKRFieldConfig;
+use mpi_config::MPIConfig;
+use transcript::Transcript;
+
+use crate::{PCSForExpanderGKR, StructuredReferenceString};
 
 #[derive(Clone, Debug, Default)]
 pub struct PCSEmptyType {}
@@ -23,4 +27,37 @@ impl StructuredReferenceString for PCSEmptyType {
     fn into_keys(self) -> (Self::PKey, Self::VKey) {
         (Self {}, Self {})
     }
+}
+
+#[allow(clippy::type_complexity)]
+pub fn expander_pcs_init_testing_only<
+    FieldConfig: GKRFieldConfig,
+    T: Transcript<FieldConfig::ChallengeField>,
+    PCS: PCSForExpanderGKR<FieldConfig, T>,
+>(
+    n_input_vars: usize,
+    mpi_config: &MPIConfig,
+    mut rng: impl rand::RngCore,
+) -> (
+    PCS::Params,
+    <PCS::SRS as StructuredReferenceString>::PKey,
+    <PCS::SRS as StructuredReferenceString>::VKey,
+    PCS::ScratchPad,
+) {
+    let pcs_params = <PCS as PCSForExpanderGKR<FieldConfig, T>>::gen_params(n_input_vars);
+    let pcs_setup = <PCS as PCSForExpanderGKR<FieldConfig, T>>::gen_srs_for_testing(
+        &pcs_params,
+        mpi_config,
+        &mut rng,
+    );
+    let (pcs_proving_key, pcs_verification_key) = pcs_setup.into_keys();
+    let pcs_scratch =
+        <PCS as PCSForExpanderGKR<FieldConfig, T>>::init_scratch_pad(&pcs_params, mpi_config);
+
+    (
+        pcs_params,
+        pcs_proving_key,
+        pcs_verification_key,
+        pcs_scratch,
+    )
 }


### PR DESCRIPTION
As discussed in #150 (https://github.com/PolyhedraZK/Expander/pull/150#discussion_r1850938446), we want to allow for  randomness being passed in for PCS init, rather than calling randomness form thread rng in an ad hoc style.  This PR refactored into `gkr` crate and `pcs` crate, resolving this problem. 

This is part of #153 , that is taken out to make review easier.