### PR TITLE
typo fix mpi_config.rs

### DIFF
--- a/config/src/mpi_config.rs
+++ b/config/src/mpi_config.rs
@@ -201,7 +201,7 @@ impl MPIConfig {
         }
     }
 
-    /// Root process broadcase a value f into all the processes
+    /// Root process broadcast a value f into all the processes
     #[inline]
     pub fn root_broadcast<F: Field>(&self, f: &mut F) {
         unsafe {


### PR DESCRIPTION
### Pull Request Title:
Typo Fix in `mpi_config.rs`

### Description:
This pull request addresses a typo in the `mpi_config.rs` file. The word "broadcase" has been corrected to "broadcast" to fix the spelling error in the comment.

### Changes:
- Corrected the typo from "broadcase" to "broadcast" in the `root_broadcast` function comment.

### Checklist:
- [x] I have reviewed the changes made in this pull request.
- [x] I have verified that the typo was fixed correctly.

### Additional Notes:
No additional notes or changes.
