### PR TITLE
Typo fix sumcheck.cuh

### DIFF
--- a/sumcheck/cuda/include/LinearGKR/sumcheck.cuh
+++ b/sumcheck/cuda/include/LinearGKR/sumcheck.cuh
@@ -69,7 +69,7 @@ namespace gkr{
             end = std::chrono::high_resolution_clock::now();
             timer.prepare_time += (double) std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
 
-            // Polynomial Evluation
+            // Polynomial Evaluation
             F evals[3];
             helper.poly_evals_at(i_var, 2, evals, timer);
 


### PR DESCRIPTION
## Typo Fix in `sumcheck.cuh`

This pull request addresses a typo in the `sumcheck.cuh` file. The word "Evluation" has been corrected to "Evaluation."

### Changes:
- Fixed the typo **"Evluation"** to **"Evaluation"** in the `sumcheck.cuh` file.

### Checklist:
- [x] Corrected the typo.
- [x] Changes have been reviewed and tested.
