### PR TITLE
minor: replace sha3 with keccak

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ mpi = "0.8.0"
 rand = "0.8.5"
 rayon = "1.10"
 sha2 = "0.10.8"
-tiny-keccak = { version = "2.0.2", features = [ "sha3", "keccak" ] }
+tiny-keccak = { version = "2.0.2", features = [ "keccak" ] }
 tokio = { version = "1.38.0", features = ["full"] }
 tynm = { version = "0.1.6", default-features = false }
 warp = "0.3.7"

--- a/gkr/src/gkr_configs.rs
+++ b/gkr/src/gkr_configs.rs
@@ -5,6 +5,7 @@ use gf2::GF2x128;
 use gkr_field_config::{BN254Config, GF2ExtConfig, GKRFieldConfig, M31ExtConfig};
 use mersenne31::M31x16;
 use poly_commit::{raw::RawExpanderGKR, OrionPCSForGKR};
+use transcript::Keccak256hasher;
 use transcript::{BytesHashTranscript, FieldHashTranscript, SHA256hasher};
 
 declare_gkr_config!(
@@ -13,6 +14,14 @@ declare_gkr_config!(
     FiatShamirHashType::Poseidon,
     PolynomialCommitmentType::Raw
 );
+
+declare_gkr_config!(
+    pub M31ExtConfigKeccakRaw,
+    FieldType::M31,
+    FiatShamirHashType::Keccak256,
+    PolynomialCommitmentType::Raw
+);
+
 declare_gkr_config!(
     pub M31ExtConfigSha2Orion,
     FieldType::M31,

--- a/transcript/src/fiat_shamir_hash/keccak_256.rs
+++ b/transcript/src/fiat_shamir_hash/keccak_256.rs
@@ -1,4 +1,4 @@
-use tiny_keccak::{Hasher, Sha3};
+use tiny_keccak::{Hasher, Keccak};
 
 use super::FiatShamirBytesHash;
 
@@ -15,14 +15,14 @@ impl FiatShamirBytesHash for Keccak256hasher {
 
     #[inline]
     fn hash(output: &mut [u8], input: &[u8]) {
-        let mut hasher = Sha3::v256();
+        let mut hasher = Keccak::v256();
         hasher.update(input);
         hasher.finalize(output);
     }
 
     #[inline]
     fn hash_inplace(buffer: &mut [u8]) {
-        let mut hasher = Sha3::v256();
+        let mut hasher = Keccak::v256();
         hasher.update(&*buffer);
         hasher.finalize(buffer);
     }


### PR DESCRIPTION
solidity use keccak APIs. it doesn't agree with sha3 (same algo, with a different prefix)