### PR TITLE
Minor: PCS scratch pad field serde

### DIFF
--- a/arith/src/serde.rs
+++ b/arith/src/serde.rs
@@ -23,6 +23,18 @@ pub trait FieldSerde: Sized {
     fn deserialize_from<R: Read>(reader: R) -> FieldSerdeResult<Self>;
 }
 
+impl FieldSerde for () {
+    const SERIALIZED_SIZE: usize = 0;
+
+    fn serialize_into<W: std::io::Write>(&self, _writer: W) -> FieldSerdeResult<()> {
+        Ok(())
+    }
+
+    fn deserialize_from<R: std::io::Read>(_reader: R) -> FieldSerdeResult<Self> {
+        Ok(())
+    }
+}
+
 macro_rules! field_serde_for_number {
     ($int_type: ident, $size_in_bytes: expr) => {
         impl FieldSerde for $int_type {

--- a/poly_commit/src/orion/utils.rs
+++ b/poly_commit/src/orion/utils.rs
@@ -82,7 +82,8 @@ where
     ComPackF: SimdField<Scalar = F>,
 {
     pub interleaved_alphabet_commitment: tree::Tree,
-    pub _phantom: PhantomData<ComPackF>,
+
+    _phantom: PhantomData<ComPackF>,
 }
 
 unsafe impl<F: Field, ComPackF: SimdField<Scalar = F>> Send for OrionScratchPad<F, ComPackF> {}

--- a/poly_commit/src/raw.rs
+++ b/poly_commit/src/raw.rs
@@ -62,7 +62,7 @@ impl<F: ExtensionField, T: Transcript<F>> PolynomialCommitmentScheme<F, T> for R
     const NAME: &'static str = "RawMultiLinear";
 
     type Params = RawMultiLinearParams;
-    type ScratchPad = RawMultiLinearScratchPad<F>;
+    type ScratchPad = ();
 
     type Poly = MultiLinearPoly<F>;
 
@@ -77,11 +77,7 @@ impl<F: ExtensionField, T: Transcript<F>> PolynomialCommitmentScheme<F, T> for R
         Self::SRS::default()
     }
 
-    fn init_scratch_pad(params: &Self::Params) -> Self::ScratchPad {
-        Self::ScratchPad {
-            eval_buffer: vec![F::ZERO; 1 << params.n_vars],
-        }
-    }
+    fn init_scratch_pad(_params: &Self::Params) -> Self::ScratchPad {}
 
     fn commit(
         params: &Self::Params,
@@ -135,9 +131,6 @@ pub struct RawExpanderGKRParams {
     pub n_local_vars: usize,
 }
 
-#[derive(Clone, Debug, Default)]
-pub struct RawExpanderGKRScratchPad {}
-
 pub struct RawExpanderGKR<C: GKRFieldConfig, T: Transcript<C::ChallengeField>> {
     _phantom: std::marker::PhantomData<(C, T)>,
 }
@@ -157,7 +150,7 @@ impl<C: GKRFieldConfig, T: Transcript<C::ChallengeField>> PCSForExpanderGKR<C, T
     //     Vec<C::ChallengeField>, // x_mpi
     // );
 
-    type ScratchPad = RawExpanderGKRScratchPad;
+    type ScratchPad = ();
 
     type SRS = PCSEmptyType;
 
@@ -179,9 +172,7 @@ impl<C: GKRFieldConfig, T: Transcript<C::ChallengeField>> PCSForExpanderGKR<C, T
         }
     }
 
-    fn init_scratch_pad(_params: &Self::Params, _mpi_config: &MPIConfig) -> Self::ScratchPad {
-        RawExpanderGKRScratchPad {}
-    }
+    fn init_scratch_pad(_params: &Self::Params, _mpi_config: &MPIConfig) -> Self::ScratchPad {}
 
     fn commit(
         params: &Self::Params,

--- a/poly_commit/src/traits.rs
+++ b/poly_commit/src/traits.rs
@@ -22,7 +22,7 @@ pub trait PolynomialCommitmentScheme<F: ExtensionField, T: Transcript<F>> {
     type Params: Clone + Debug + Default;
     type Poly: Clone + Debug + Default;
     type EvalPoint: Clone + Debug + Default;
-    type ScratchPad: Clone + Debug + Default;
+    type ScratchPad: Clone + Debug + Default + FieldSerde;
 
     type SRS: Clone + Debug + Default + FieldSerde + StructuredReferenceString;
     type Commitment: Clone + Debug + Default + FieldSerde;
@@ -96,7 +96,7 @@ pub trait PCSForExpanderGKR<C: GKRFieldConfig, T: Transcript<C::ChallengeField>>
     const NAME: &'static str;
 
     type Params: Clone + Debug + Default + Send;
-    type ScratchPad: Clone + Debug + Default + Send;
+    type ScratchPad: Clone + Debug + Default + Send + FieldSerde;
 
     type SRS: Clone + Debug + Default + FieldSerde + StructuredReferenceString;
     type Commitment: Clone + Debug + Default + FieldSerde;

--- a/tree/src/serde.rs
+++ b/tree/src/serde.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 
 use arith::{FieldSerde, FieldSerdeResult};
 
-use crate::{Leaf, Node, Path, RangePath, LEAF_BYTES, LEAF_HASH_BYTES};
+use crate::{Leaf, Node, Path, RangePath, Tree, LEAF_BYTES, LEAF_HASH_BYTES};
 
 impl FieldSerde for Leaf {
     const SERIALIZED_SIZE: usize = LEAF_BYTES;
@@ -80,5 +80,21 @@ impl FieldSerde for RangePath {
             path_nodes,
             leaves,
         })
+    }
+}
+
+impl FieldSerde for Tree {
+    const SERIALIZED_SIZE: usize = unimplemented!();
+
+    fn serialize_into<W: Write>(&self, mut writer: W) -> FieldSerdeResult<()> {
+        self.nodes.serialize_into(&mut writer)?;
+        self.leaves.serialize_into(&mut writer)
+    }
+
+    fn deserialize_from<R: Read>(mut reader: R) -> FieldSerdeResult<Self> {
+        let nodes = Vec::deserialize_from(&mut reader)?;
+        let leaves = Vec::deserialize_from(&mut reader)?;
+
+        Ok(Self { nodes, leaves })
     }
 }


### PR DESCRIPTION
Prior request from upstream - supposing the computational graph needs the PCS scratch for circuit inputs/witnesses, then these PCS scratches should be (de)serializable.