### PR TITLE
Minor: SIMD field method horizontal sum, and a weird application

### DIFF
--- a/arith/mersenne31/src/m31_ext3x16.rs
+++ b/arith/mersenne31/src/m31_ext3x16.rs
@@ -81,6 +81,18 @@ impl SimdField for M31Ext3x16 {
             .map(|((v0, v1), v2)| M31Ext3 { v: [v0, v1, v2] })
             .collect()
     }
+
+    #[inline(always)]
+    fn horizontal_sum(&self) -> Self::Scalar {
+        let limbs = self.to_limbs();
+        Self::Scalar {
+            v: [
+                limbs[0].horizontal_sum(),
+                limbs[1].horizontal_sum(),
+                limbs[2].horizontal_sum(),
+            ],
+        }
+    }
 }
 
 impl From<M31x16> for M31Ext3x16 {

--- a/arith/mersenne31/src/m31x16/m31_avx256.rs
+++ b/arith/mersenne31/src/m31x16/m31_avx256.rs
@@ -284,15 +284,47 @@ impl SimdField for AVXM31 {
 
     const PACK_SIZE: usize = M31_PACK_SIZE;
 
+    #[inline(always)]
     fn pack(base_vec: &[Self::Scalar]) -> Self {
         assert_eq!(base_vec.len(), M31_PACK_SIZE);
         let ret: [Self::Scalar; M31_PACK_SIZE] = base_vec.try_into().unwrap();
         unsafe { transmute(ret) }
     }
 
+    #[inline(always)]
     fn unpack(&self) -> Vec<Self::Scalar> {
         let ret = unsafe { transmute::<[__m256i; 2], [Self::Scalar; M31_PACK_SIZE]>(self.v) };
         ret.to_vec()
+    }
+
+    #[inline(always)]
+    fn horizontal_sum(&self) -> Self::Scalar {
+        let mut buffer = 0u64;
+        let ret = unsafe { transmute::<[__m256i; 2], [Self::Scalar; M31_PACK_SIZE]>(self.v) };
+
+        buffer += ret[0].v as u64;
+        buffer += ret[1].v as u64;
+        buffer += ret[2].v as u64;
+        buffer += ret[3].v as u64;
+        buffer += ret[4].v as u64;
+        buffer += ret[5].v as u64;
+        buffer += ret[6].v as u64;
+        buffer += ret[7].v as u64;
+        buffer += ret[8].v as u64;
+        buffer += ret[9].v as u64;
+        buffer += ret[10].v as u64;
+        buffer += ret[11].v as u64;
+        buffer += ret[12].v as u64;
+        buffer += ret[13].v as u64;
+        buffer += ret[14].v as u64;
+        buffer += ret[15].v as u64;
+
+        buffer = (buffer & M31_MOD as u64) + (buffer >> 31);
+        if buffer == M31_MOD as u64 {
+            Self::Scalar::ZERO
+        } else {
+            Self::Scalar { v: buffer as u32 }
+        }
     }
 }
 

--- a/arith/mersenne31/src/m31x16/m31_avx256.rs
+++ b/arith/mersenne31/src/m31x16/m31_avx256.rs
@@ -299,26 +299,8 @@ impl SimdField for AVXM31 {
 
     #[inline(always)]
     fn horizontal_sum(&self) -> Self::Scalar {
-        let mut buffer = 0u64;
         let ret = unsafe { transmute::<[__m256i; 2], [Self::Scalar; M31_PACK_SIZE]>(self.v) };
-
-        buffer += ret[0].v as u64;
-        buffer += ret[1].v as u64;
-        buffer += ret[2].v as u64;
-        buffer += ret[3].v as u64;
-        buffer += ret[4].v as u64;
-        buffer += ret[5].v as u64;
-        buffer += ret[6].v as u64;
-        buffer += ret[7].v as u64;
-        buffer += ret[8].v as u64;
-        buffer += ret[9].v as u64;
-        buffer += ret[10].v as u64;
-        buffer += ret[11].v as u64;
-        buffer += ret[12].v as u64;
-        buffer += ret[13].v as u64;
-        buffer += ret[14].v as u64;
-        buffer += ret[15].v as u64;
-
+        let mut buffer = ret.iter().map(|r| r.v as u64).sum::<u64>();
         buffer = (buffer & M31_MOD as u64) + (buffer >> 31);
         if buffer == M31_MOD as u64 {
             Self::Scalar::ZERO

--- a/arith/mersenne31/src/m31x16/m31_avx512.rs
+++ b/arith/mersenne31/src/m31x16/m31_avx512.rs
@@ -254,26 +254,8 @@ impl SimdField for AVXM31 {
 
     #[inline(always)]
     fn horizontal_sum(&self) -> Self::Scalar {
-        let mut buffer = 0u64;
         let ret = unsafe { transmute::<__m512i, [Self::Scalar; M31_PACK_SIZE]>(self.v) };
-
-        buffer += ret[0].v as u64;
-        buffer += ret[1].v as u64;
-        buffer += ret[2].v as u64;
-        buffer += ret[3].v as u64;
-        buffer += ret[4].v as u64;
-        buffer += ret[5].v as u64;
-        buffer += ret[6].v as u64;
-        buffer += ret[7].v as u64;
-        buffer += ret[8].v as u64;
-        buffer += ret[9].v as u64;
-        buffer += ret[10].v as u64;
-        buffer += ret[11].v as u64;
-        buffer += ret[12].v as u64;
-        buffer += ret[13].v as u64;
-        buffer += ret[14].v as u64;
-        buffer += ret[15].v as u64;
-
+        let mut buffer = ret.iter().map(|r| r.v as u64).sum::<u64>();
         buffer = (buffer & M31_MOD as u64) + (buffer >> 31);
         if buffer == M31_MOD as u64 {
             Self::Scalar::ZERO

--- a/arith/mersenne31/src/m31x16/m31_avx512.rs
+++ b/arith/mersenne31/src/m31x16/m31_avx512.rs
@@ -251,6 +251,36 @@ impl SimdField for AVXM31 {
         let ret = unsafe { transmute::<__m512i, [Self::Scalar; M31_PACK_SIZE]>(self.v) };
         ret.to_vec()
     }
+
+    #[inline(always)]
+    fn horizontal_sum(&self) -> Self::Scalar {
+        let mut buffer = 0u64;
+        let ret = unsafe { transmute::<__m512i, [Self::Scalar; M31_PACK_SIZE]>(self.v) };
+
+        buffer += ret[0].v as u64;
+        buffer += ret[1].v as u64;
+        buffer += ret[2].v as u64;
+        buffer += ret[3].v as u64;
+        buffer += ret[4].v as u64;
+        buffer += ret[5].v as u64;
+        buffer += ret[6].v as u64;
+        buffer += ret[7].v as u64;
+        buffer += ret[8].v as u64;
+        buffer += ret[9].v as u64;
+        buffer += ret[10].v as u64;
+        buffer += ret[11].v as u64;
+        buffer += ret[12].v as u64;
+        buffer += ret[13].v as u64;
+        buffer += ret[14].v as u64;
+        buffer += ret[15].v as u64;
+
+        buffer = (buffer & M31_MOD as u64) + (buffer >> 31);
+        if buffer == M31_MOD as u64 {
+            Self::Scalar::ZERO
+        } else {
+            Self::Scalar { v: buffer as u32 }
+        }
+    }
 }
 
 impl From<M31> for AVXM31 {

--- a/arith/mersenne31/src/m31x16/m31_neon.rs
+++ b/arith/mersenne31/src/m31x16/m31_neon.rs
@@ -315,6 +315,36 @@ impl SimdField for NeonM31 {
         let ret = unsafe { transmute::<[uint32x4_t; 4], [Self::Scalar; M31_PACK_SIZE]>(self.v) };
         ret.to_vec()
     }
+
+    #[inline(always)]
+    fn horizontal_sum(&self) -> Self::Scalar {
+        let mut buffer = 0u64;
+        let ret = unsafe { transmute::<[uint32x4_t; 4], [Self::Scalar; M31_PACK_SIZE]>(self.v) };
+
+        buffer += ret[0].v as u64;
+        buffer += ret[1].v as u64;
+        buffer += ret[2].v as u64;
+        buffer += ret[3].v as u64;
+        buffer += ret[4].v as u64;
+        buffer += ret[5].v as u64;
+        buffer += ret[6].v as u64;
+        buffer += ret[7].v as u64;
+        buffer += ret[8].v as u64;
+        buffer += ret[9].v as u64;
+        buffer += ret[10].v as u64;
+        buffer += ret[11].v as u64;
+        buffer += ret[12].v as u64;
+        buffer += ret[13].v as u64;
+        buffer += ret[14].v as u64;
+        buffer += ret[15].v as u64;
+
+        buffer = (buffer & M31_MOD as u64) + (buffer >> 31);
+        if buffer == M31_MOD as u64 {
+            Self::Scalar::ZERO
+        } else {
+            Self::Scalar { v: buffer as u32 }
+        }
+    }
 }
 
 impl From<M31> for NeonM31 {

--- a/arith/mersenne31/src/m31x16/m31_neon.rs
+++ b/arith/mersenne31/src/m31x16/m31_neon.rs
@@ -318,26 +318,8 @@ impl SimdField for NeonM31 {
 
     #[inline(always)]
     fn horizontal_sum(&self) -> Self::Scalar {
-        let mut buffer = 0u64;
         let ret = unsafe { transmute::<[uint32x4_t; 4], [Self::Scalar; M31_PACK_SIZE]>(self.v) };
-
-        buffer += ret[0].v as u64;
-        buffer += ret[1].v as u64;
-        buffer += ret[2].v as u64;
-        buffer += ret[3].v as u64;
-        buffer += ret[4].v as u64;
-        buffer += ret[5].v as u64;
-        buffer += ret[6].v as u64;
-        buffer += ret[7].v as u64;
-        buffer += ret[8].v as u64;
-        buffer += ret[9].v as u64;
-        buffer += ret[10].v as u64;
-        buffer += ret[11].v as u64;
-        buffer += ret[12].v as u64;
-        buffer += ret[13].v as u64;
-        buffer += ret[14].v as u64;
-        buffer += ret[15].v as u64;
-
+        let mut buffer = ret.iter().map(|r| r.v as u64).sum::<u64>();
         buffer = (buffer & M31_MOD as u64) + (buffer >> 31);
         if buffer == M31_MOD as u64 {
             Self::Scalar::ZERO

--- a/arith/src/simd_field.rs
+++ b/arith/src/simd_field.rs
@@ -33,4 +33,9 @@ pub trait SimdField: From<Self::Scalar> + Field {
 
     /// unpack into a vector.
     fn unpack(&self) -> Vec<Self::Scalar>;
+
+    /// horizontally sum all packed scalars
+    fn horizontal_sum(&self) -> Self::Scalar {
+        self.unpack().iter().sum()
+    }
 }

--- a/poly_commit/src/orion/utils.rs
+++ b/poly_commit/src/orion/utils.rs
@@ -401,7 +401,7 @@ where
             let simd_sum: SimdF = izip!(simd_ext_limb, simd_base_elems)
                 .map(|(a, b)| *a * b)
                 .sum();
-            *e = simd_sum.unpack().iter().sum()
+            *e = simd_sum.horizontal_sum();
         },
     );
 
@@ -538,7 +538,7 @@ mod tests {
         let simd_weights = GF2_128x8::pack(&weights);
         let simd_bases = GF2x8::pack(&bases);
 
-        let expected_simd_inner_prod: GF2_128 = (simd_weights * simd_bases).unpack().iter().sum();
+        let expected_simd_inner_prod: GF2_128 = (simd_weights * simd_bases).horizontal_sum();
 
         let expected_vanilla_inner_prod: GF2_128 =
             izip!(&weights, &bases).map(|(w, b)| *w * *b).sum();

--- a/sumcheck/src/utils.rs
+++ b/sumcheck/src/utils.rs
@@ -15,6 +15,11 @@ use transcript::Transcript;
 /// Output
 /// - p0 * c0 + ... + pn * cn
 pub fn unpack_and_combine<F: SimdField>(p: &F, coef: &[F::Scalar]) -> F::Scalar {
+    if coef.len() >= F::PACK_SIZE {
+        let coef_packed = F::pack(&coef[..F::PACK_SIZE]);
+        return (coef_packed * p).horizontal_sum();
+    }
+
     let p_unpacked = p.unpack();
     p_unpacked
         .into_iter()


### PR DESCRIPTION
tldr: M31x16 horizontal sum can skip a bunch of mod reductions, then Orion M31 opening gets 50% faster.