### PR TITLE
Fix some field operations

### DIFF
--- a/arith/goldilocks/src/goldilocks.rs
+++ b/arith/goldilocks/src/goldilocks.rs
@@ -25,7 +25,7 @@ pub(crate) fn mod_reduce_u64(x: u64) -> u64 {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct Goldilocks {
     pub v: u64,
 }
@@ -38,6 +38,20 @@ impl PartialEq for Goldilocks {
 }
 
 impl Eq for Goldilocks {}
+
+impl PartialOrd for Goldilocks {
+    #[inline(always)]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Goldilocks {
+    #[inline(always)]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        mod_reduce_u64(self.v).cmp(&mod_reduce_u64(other.v))
+    }
+}
 
 field_common!(Goldilocks);
 
@@ -106,12 +120,12 @@ impl Field for Goldilocks {
 
     #[inline(always)]
     fn to_u256(&self) -> U256 {
-        U256([self.v as u128, 0])
+        U256([mod_reduce_u64(self.v) as u128, 0])
     }
 
     #[inline(always)]
     fn from_u256(value: U256) -> Self {
-        assert!(value < Self::MODULUS);
+        let value = value % Self::MODULUS;
         // TODO: this is a hack to get the low 64 bits of the u256
         // TODO: we should remove the assumption that the top bits are 0s
         let (_high, low) = value.into_words();
@@ -230,7 +244,7 @@ fn mul_internal(a: &Goldilocks, b: &Goldilocks) -> Goldilocks {
 impl std::hash::Hash for Goldilocks {
     #[inline(always)]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        state.write_u64(self.v);
+        state.write_u64(mod_reduce_u64(self.v));
     }
 }
 
@@ -367,7 +381,7 @@ pub(crate) mod p2_instructions {
         let mut c = 1i128;
         let mut d = 0i128;
 
-        if f == 0 {
+        if f == 0 || f == GOLDILOCKS_MOD {
             return None;
         }
 

--- a/arith/mersenne31/src/m31.rs
+++ b/arith/mersenne31/src/m31.rs
@@ -32,7 +32,7 @@ fn mod_reduce_i64(x: i64) -> i64 {
     (x & M31_MOD as i64) + (x >> 31)
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct M31 {
     pub v: u32,
 }
@@ -45,6 +45,20 @@ impl PartialEq for M31 {
 }
 
 impl Eq for M31 {}
+
+impl PartialOrd for M31 {
+    #[inline(always)]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for M31 {
+    #[inline(always)]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        mod_reduce_u32_safe(self.v).cmp(&mod_reduce_u32_safe(other.v))
+    }
+}
 
 field_common!(M31);
 
@@ -125,7 +139,7 @@ impl Field for M31 {
 
     #[inline(always)]
     fn to_u256(&self) -> U256 {
-        U256([self.v as u128, 0])
+        U256([mod_reduce_u32_safe(self.v) as u128, 0])
     }
 
     #[inline(always)]
@@ -287,6 +301,6 @@ fn mul_internal(a: &M31, b: &M31) -> M31 {
 impl std::hash::Hash for M31 {
     #[inline(always)]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        state.write_u32(self.v);
+        state.write_u32(mod_reduce_u32_safe(self.v));
     }
 }


### PR DESCRIPTION
Fixes:
1. Goldilocks `try_inverse_u64` should check `x == GOLDILOCKS_MOD`
2. Goldilocks `from_u256` should handle `value >= GOLDILOCKS_MOD`
3. In Goldilocks and M31, some functions uses the raw value `v`, including `to_u256`, `Hash`, `PartialOrd`, `Ord`. But the inner `v` might be `>= MOD`. We should reduce it first.

These bugs make ECC Goldilocks tests failed. Bug 3 might affect M31, but it didn't. Maybe it's because the probability is too low for M31.