### PR TITLE
SIMD: GF2x8 bit ordering in machine order

### DIFF
--- a/arith/gf2/src/gf2x128.rs
+++ b/arith/gf2/src/gf2x128.rs
@@ -43,7 +43,6 @@ impl SimdField for GF2x128 {
         let mut packed_to_gf2x64 = [GF2x64::ZERO; Self::PACK_SIZE / GF2x64::PACK_SIZE];
         packed_to_gf2x64
             .iter_mut()
-            .rev()
             .zip(base_vec.chunks(GF2x64::PACK_SIZE))
             .for_each(|(gf2x64, pack)| *gf2x64 = GF2x64::pack(pack));
 
@@ -57,7 +56,6 @@ impl SimdField for GF2x128 {
 
         packed_to_gf2x64
             .iter()
-            .rev()
             .flat_map(|packed| packed.unpack())
             .collect()
     }

--- a/arith/gf2/src/gf2x8.rs
+++ b/arith/gf2/src/gf2x8.rs
@@ -287,7 +287,7 @@ impl SimdField for GF2x8 {
         assert!(base_vec.len() == Self::PACK_SIZE);
         let mut ret = 0u8;
         for (i, scalar) in base_vec.iter().enumerate() {
-            ret |= scalar.v << (7 - i);
+            ret |= scalar.v << i;
         }
         Self { v: ret }
     }
@@ -297,7 +297,7 @@ impl SimdField for GF2x8 {
         let mut ret = vec![];
         for i in 0..Self::PACK_SIZE {
             ret.push(Self::Scalar {
-                v: (self.v >> (7 - i)) & 1u8,
+                v: (self.v >> i) & 1u8,
             });
         }
         ret

--- a/arith/gf2/src/tests.rs
+++ b/arith/gf2/src/tests.rs
@@ -1,9 +1,7 @@
 use ark_std::test_rng;
 use std::io::Cursor;
 
-use arith::{
-    random_field_tests, random_inversion_tests, random_simd_field_tests, Field, SimdField,
-};
+use arith::{random_field_tests, random_inversion_tests, random_simd_field_tests, SimdField};
 
 use crate::{GF2x128, GF2x64, GF2x8, GF2};
 
@@ -38,21 +36,6 @@ fn custom_serde_vectorize_gf2<F: SimdField<Scalar = GF2>>() {
     assert!(b.is_ok());
     let b = b.unwrap();
     assert_eq!(a, b);
-
-    let mut random_packed = vec![GF2x8::ZERO; F::PACK_SIZE / GF2x8::PACK_SIZE];
-    random_packed
-        .iter_mut()
-        .for_each(|v| *v = GF2x8::random_unsafe(&mut rng));
-
-    let actual_packed = F::pack_from_simd(&random_packed);
-    let expected_packed = F::pack(
-        &random_packed
-            .iter()
-            .flat_map(|v| v.unpack())
-            .collect::<Vec<_>>(),
-    );
-
-    assert_eq!(actual_packed, expected_packed);
 }
 
 #[test]

--- a/arith/gf2_128/src/gf2_ext128x8/avx256.rs
+++ b/arith/gf2_128/src/gf2_ext128x8/avx256.rs
@@ -574,14 +574,14 @@ impl ExtensionField for AVX256GF2_128x8 {
     #[inline(always)]
     fn mul_by_base_field(&self, base: &Self::BaseField) -> Self {
         // -1 -> 0b11111111
-        let v0 = -(((base.v >> 7) & 1u8) as i64);
-        let v1 = -(((base.v >> 6) & 1u8) as i64);
-        let v2 = -(((base.v >> 5) & 1u8) as i64);
-        let v3 = -(((base.v >> 4) & 1u8) as i64);
-        let v4 = -(((base.v >> 3) & 1u8) as i64);
-        let v5 = -(((base.v >> 2) & 1u8) as i64);
-        let v6 = -(((base.v >> 1) & 1u8) as i64);
-        let v7 = -((base.v & 1u8) as i64);
+        let v0 = -((base.v & 1u8) as i64);
+        let v1 = -(((base.v >> 1) & 1u8) as i64);
+        let v2 = -(((base.v >> 2) & 1u8) as i64);
+        let v3 = -(((base.v >> 3) & 1u8) as i64);
+        let v4 = -(((base.v >> 4) & 1u8) as i64);
+        let v5 = -(((base.v >> 5) & 1u8) as i64);
+        let v6 = -(((base.v >> 6) & 1u8) as i64);
+        let v7 = -(((base.v >> 7) & 1u8) as i64);
 
         let mut res = *self;
         res.data[0] = unsafe { _mm256_and_si256(res.data[0], _mm256_set_epi64x(v1, v1, v0, v0)) };
@@ -594,14 +594,14 @@ impl ExtensionField for AVX256GF2_128x8 {
 
     #[inline(always)]
     fn add_by_base_field(&self, base: &Self::BaseField) -> Self {
-        let v0 = ((base.v >> 7) & 1u8) as i64;
-        let v1 = ((base.v >> 6) & 1u8) as i64;
-        let v2 = ((base.v >> 5) & 1u8) as i64;
-        let v3 = ((base.v >> 4) & 1u8) as i64;
-        let v4 = ((base.v >> 3) & 1u8) as i64;
-        let v5 = ((base.v >> 2) & 1u8) as i64;
-        let v6 = ((base.v >> 1) & 1u8) as i64;
-        let v7 = (base.v & 1u8) as i64;
+        let v0 = (base.v & 1u8) as i64;
+        let v1 = ((base.v >> 1) & 1u8) as i64;
+        let v2 = ((base.v >> 2) & 1u8) as i64;
+        let v3 = ((base.v >> 3) & 1u8) as i64;
+        let v4 = ((base.v >> 4) & 1u8) as i64;
+        let v5 = ((base.v >> 5) & 1u8) as i64;
+        let v6 = ((base.v >> 6) & 1u8) as i64;
+        let v7 = ((base.v >> 7) & 1u8) as i64;
 
         let mut res = *self;
         res.data[0] = unsafe { _mm256_xor_si256(res.data[0], _mm256_set_epi64x(0, v1, 0, v0)) };
@@ -706,14 +706,14 @@ impl Mul<GF2x8> for AVX256GF2_128x8 {
 impl From<GF2x8> for AVX256GF2_128x8 {
     #[inline(always)]
     fn from(v: GF2x8) -> Self {
-        let v0 = ((v.v >> 7) & 1u8) as i64;
-        let v1 = ((v.v >> 6) & 1u8) as i64;
-        let v2 = ((v.v >> 5) & 1u8) as i64;
-        let v3 = ((v.v >> 4) & 1u8) as i64;
-        let v4 = ((v.v >> 3) & 1u8) as i64;
-        let v5 = ((v.v >> 2) & 1u8) as i64;
-        let v6 = ((v.v >> 1) & 1u8) as i64;
-        let v7 = (v.v & 1u8) as i64;
+        let v0 = (v.v & 1u8) as i64;
+        let v1 = ((v.v >> 1) & 1u8) as i64;
+        let v2 = ((v.v >> 2) & 1u8) as i64;
+        let v3 = ((v.v >> 3) & 1u8) as i64;
+        let v4 = ((v.v >> 4) & 1u8) as i64;
+        let v5 = ((v.v >> 5) & 1u8) as i64;
+        let v6 = ((v.v >> 6) & 1u8) as i64;
+        let v7 = ((v.v >> 7) & 1u8) as i64;
 
         AVX256GF2_128x8 {
             data: [

--- a/arith/gf2_128/src/gf2_ext128x8/avx512.rs
+++ b/arith/gf2_128/src/gf2_ext128x8/avx512.rs
@@ -572,27 +572,27 @@ impl ExtensionField for AVX512GF2_128x8 {
 
     #[inline(always)]
     fn mul_by_base_field(&self, base: &Self::BaseField) -> Self {
-        let mask_high = duplicate_higher_4bits(base.v).reverse_bits();
-        let mask_low = duplicate_lower_4bits(base.v).reverse_bits();
+        let mask_high = duplicate_higher_4bits(base.v);
+        let mask_low = duplicate_lower_4bits(base.v);
 
         Self {
             data: [
-                unsafe { _mm512_maskz_mov_epi64(mask_high, self.data[0]) },
-                unsafe { _mm512_maskz_mov_epi64(mask_low, self.data[1]) },
+                unsafe { _mm512_maskz_mov_epi64(mask_low, self.data[0]) },
+                unsafe { _mm512_maskz_mov_epi64(mask_high, self.data[1]) },
             ],
         }
     }
 
     #[inline(always)]
     fn add_by_base_field(&self, base: &Self::BaseField) -> Self {
-        let v0 = ((base.v >> 7) & 1u8) as i64;
-        let v1 = ((base.v >> 6) & 1u8) as i64;
-        let v2 = ((base.v >> 5) & 1u8) as i64;
-        let v3 = ((base.v >> 4) & 1u8) as i64;
-        let v4 = ((base.v >> 3) & 1u8) as i64;
-        let v5 = ((base.v >> 2) & 1u8) as i64;
-        let v6 = ((base.v >> 1) & 1u8) as i64;
-        let v7 = (base.v & 1u8) as i64;
+        let v0 = (base.v & 1u8) as i64;
+        let v1 = ((base.v >> 1) & 1u8) as i64;
+        let v2 = ((base.v >> 2) & 1u8) as i64;
+        let v3 = ((base.v >> 3) & 1u8) as i64;
+        let v4 = ((base.v >> 4) & 1u8) as i64;
+        let v5 = ((base.v >> 5) & 1u8) as i64;
+        let v6 = ((base.v >> 6) & 1u8) as i64;
+        let v7 = ((base.v >> 7) & 1u8) as i64;
 
         let mut res = *self;
         res.data[0] = unsafe {
@@ -694,14 +694,14 @@ impl ExtensionField for AVX512GF2_128x8 {
 impl From<GF2x8> for AVX512GF2_128x8 {
     #[inline(always)]
     fn from(v: GF2x8) -> Self {
-        let v0 = ((v.v >> 7) & 1u8) as i64;
-        let v1 = ((v.v >> 6) & 1u8) as i64;
-        let v2 = ((v.v >> 5) & 1u8) as i64;
-        let v3 = ((v.v >> 4) & 1u8) as i64;
-        let v4 = ((v.v >> 3) & 1u8) as i64;
-        let v5 = ((v.v >> 2) & 1u8) as i64;
-        let v6 = ((v.v >> 1) & 1u8) as i64;
-        let v7 = (v.v & 1u8) as i64;
+        let v0 = (v.v & 1u8) as i64;
+        let v1 = ((v.v >> 1) & 1u8) as i64;
+        let v2 = ((v.v >> 2) & 1u8) as i64;
+        let v3 = ((v.v >> 3) & 1u8) as i64;
+        let v4 = ((v.v >> 4) & 1u8) as i64;
+        let v5 = ((v.v >> 5) & 1u8) as i64;
+        let v6 = ((v.v >> 6) & 1u8) as i64;
+        let v7 = ((v.v >> 7) & 1u8) as i64;
 
         AVX512GF2_128x8 {
             data: [

--- a/arith/gf2_128/src/gf2_ext128x8/neon.rs
+++ b/arith/gf2_128/src/gf2_ext128x8/neon.rs
@@ -281,14 +281,14 @@ impl ExtensionField for NeonGF2_128x8 {
 
     #[inline(always)]
     fn mul_by_base_field(&self, base: &Self::BaseField) -> Self {
-        let v0 = ((base.v >> 7) & 1u8) as u32;
-        let v1 = ((base.v >> 6) & 1u8) as u32;
-        let v2 = ((base.v >> 5) & 1u8) as u32;
-        let v3 = ((base.v >> 4) & 1u8) as u32;
-        let v4 = ((base.v >> 3) & 1u8) as u32;
-        let v5 = ((base.v >> 2) & 1u8) as u32;
-        let v6 = ((base.v >> 1) & 1u8) as u32;
-        let v7 = (base.v & 1u8) as u32;
+        let v0 = (base.v & 1u8) as u32;
+        let v1 = ((base.v >> 1) & 1u8) as u32;
+        let v2 = ((base.v >> 2) & 1u8) as u32;
+        let v3 = ((base.v >> 3) & 1u8) as u32;
+        let v4 = ((base.v >> 4) & 1u8) as u32;
+        let v5 = ((base.v >> 5) & 1u8) as u32;
+        let v6 = ((base.v >> 6) & 1u8) as u32;
+        let v7 = ((base.v >> 7) & 1u8) as u32;
 
         Self {
             v: [
@@ -306,14 +306,14 @@ impl ExtensionField for NeonGF2_128x8 {
 
     #[inline(always)]
     fn add_by_base_field(&self, base: &Self::BaseField) -> Self {
-        let v0 = ((base.v >> 7) & 1u8) as u32;
-        let v1 = ((base.v >> 6) & 1u8) as u32;
-        let v2 = ((base.v >> 5) & 1u8) as u32;
-        let v3 = ((base.v >> 4) & 1u8) as u32;
-        let v4 = ((base.v >> 3) & 1u8) as u32;
-        let v5 = ((base.v >> 2) & 1u8) as u32;
-        let v6 = ((base.v >> 1) & 1u8) as u32;
-        let v7 = (base.v & 1u8) as u32;
+        let v0 = (base.v & 1u8) as u32;
+        let v1 = ((base.v >> 1) & 1u8) as u32;
+        let v2 = ((base.v >> 2) & 1u8) as u32;
+        let v3 = ((base.v >> 3) & 1u8) as u32;
+        let v4 = ((base.v >> 4) & 1u8) as u32;
+        let v5 = ((base.v >> 5) & 1u8) as u32;
+        let v6 = ((base.v >> 6) & 1u8) as u32;
+        let v7 = ((base.v >> 7) & 1u8) as u32;
 
         Self {
             v: [
@@ -387,14 +387,14 @@ impl ExtensionField for NeonGF2_128x8 {
 impl From<GF2x8> for NeonGF2_128x8 {
     #[inline(always)]
     fn from(v: GF2x8) -> Self {
-        let v0 = ((v.v >> 7) & 1u8) as u32;
-        let v1 = ((v.v >> 6) & 1u8) as u32;
-        let v2 = ((v.v >> 5) & 1u8) as u32;
-        let v3 = ((v.v >> 4) & 1u8) as u32;
-        let v4 = ((v.v >> 3) & 1u8) as u32;
-        let v5 = ((v.v >> 2) & 1u8) as u32;
-        let v6 = ((v.v >> 1) & 1u8) as u32;
-        let v7 = (v.v & 1u8) as u32;
+        let v0 = (v.v & 1u8) as u32;
+        let v1 = ((v.v >> 1) & 1u8) as u32;
+        let v2 = ((v.v >> 2) & 1u8) as u32;
+        let v3 = ((v.v >> 3) & 1u8) as u32;
+        let v4 = ((v.v >> 4) & 1u8) as u32;
+        let v5 = ((v.v >> 5) & 1u8) as u32;
+        let v6 = ((v.v >> 6) & 1u8) as u32;
+        let v7 = ((v.v >> 7) & 1u8) as u32;
 
         NeonGF2_128x8 {
             v: [

--- a/arith/src/simd_field.rs
+++ b/arith/src/simd_field.rs
@@ -18,23 +18,6 @@ pub trait SimdField: From<Self::Scalar> + Field {
     /// pack a vec of scalar field into self
     fn pack(base_vec: &[Self::Scalar]) -> Self;
 
-    /// pack a vec of simd field with same scalar field into self
-    fn pack_from_simd<PackF>(simd_vec: &[PackF]) -> Self
-    where
-        PackF: SimdField<Scalar = Self::Scalar>,
-    {
-        assert_eq!(simd_vec.len() * PackF::PACK_SIZE, Self::PACK_SIZE);
-        let mut temp: Vec<_> = simd_vec.to_vec();
-        // NOTE(HS) this method `pack_from_simd` was introduced with
-        // a motivation of packing multiple GF2x8 into a GF2x64 or a GF2x128.
-        // The reverse here is to ensure that packing all these GF2x8s into a
-        // final GF2x64 can unpack into a vec of GF2s, that is the same order
-        // as a concatenation of unpacked GF2s from GF2x8.
-        temp.reverse();
-
-        unsafe { *(temp.as_ptr() as *const Self) }
-    }
-
     /// unpack into a vector.
     fn unpack(&self) -> Vec<Self::Scalar>;
 

--- a/poly_commit/src/orion/simd_field_impl.rs
+++ b/poly_commit/src/orion/simd_field_impl.rs
@@ -36,9 +36,13 @@ where
     assert_eq!(row_num % relative_pack_size, 0);
 
     assert_eq!(poly.hypercube_size() % relative_pack_size, 0);
-    let packed_evals = pack_simd::<F, SimdF, ComPackF>(poly.hypercube_basis_ref());
+    let packed_evals_ref = unsafe {
+        let ptr = poly.hypercube_basis_ref().as_ptr();
+        let len = poly.hypercube_size() / relative_pack_size;
+        std::slice::from_raw_parts(ptr as *const ComPackF, len)
+    };
 
-    commit_encoded(pk, &packed_evals, scratch_pad, packed_rows, msg_size)
+    commit_encoded(pk, packed_evals_ref, scratch_pad, packed_rows, msg_size)
 }
 
 // NOTE: this implementation doesn't quite align with opening for

--- a/poly_commit/src/orion/simd_field_tests.rs
+++ b/poly_commit/src/orion/simd_field_tests.rs
@@ -48,7 +48,10 @@ where
 
     let mut packed_interleaved_codeword: Vec<_> = interleaved_codewords
         .chunks(ComPackF::PACK_SIZE / SimdF::PACK_SIZE)
-        .map(ComPackF::pack_from_simd)
+        .map(|chunk| {
+            let elems: Vec<_> = chunk.iter().cloned().flat_map(|c| c.unpack()).collect();
+            ComPackF::pack(&elems)
+        })
         .collect();
     drop(interleaved_codewords);
 

--- a/poly_commit/src/orion/utils.rs
+++ b/poly_commit/src/orion/utils.rs
@@ -237,21 +237,6 @@ where
         .collect()
 }
 
-#[inline(always)]
-pub(crate) fn pack_simd<F, SimdF, PackF>(evaluations: &[SimdF]) -> Vec<PackF>
-where
-    F: Field,
-    SimdF: SimdField<Scalar = F>,
-    PackF: SimdField<Scalar = F>,
-{
-    // NOTE: SIMD pack neighboring SIMD evals
-    let relative_pack_size = PackF::PACK_SIZE / SimdF::PACK_SIZE;
-    evaluations
-        .chunks(relative_pack_size)
-        .map(PackF::pack_from_simd)
-        .collect()
-}
-
 /*
  * LINEAR OPERATIONS FOR GF2 (LOOKUP TABLE BASED)
  */
@@ -282,7 +267,7 @@ impl<F: Field> SubsetSumLUTs<F> {
         izip!(&mut self.tables, weights.chunks(self.entry_bits)).for_each(
             |(lut_i, sub_weights)| {
                 sub_weights.iter().enumerate().for_each(|(i, weight_i)| {
-                    let bit_mask = 1 << (self.entry_bits - i - 1);
+                    let bit_mask = 1 << i;
                     lut_i.iter_mut().enumerate().for_each(|(bit_map, li)| {
                         if bit_map & bit_mask == bit_mask {
                             *li += weight_i;


### PR DESCRIPTION
This PR was introduced from internal discussion and dev of #236, with following changes:
- `GF2x8` should be in `u8` bit ordering - that first bit to pack on lowest bit, last bit to pack on hightest bit
- Collateral changes of `GF2x64` and `GF2x128` (un)packing piggybacking `GF2x8` SIMD (un)packing
- Deleting `pack_from_simd` operation from `SIMDField` trait
- `GF2_128x8` operations with base field `GF2x8` sequences need to change: `From`, `add/mul_by_base_field`
- LUT for linear combination on Orion PCS side change entry bit ordering with `GF2x8` ordering