### PR TITLE
MPI-free verifier example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,8 +246,7 @@ dependencies = [
 [[package]]
 name = "build-probe-mpi"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3234fa6de2f6e0e338c7183ba09ae68c8f2bd6919d8763362597627362b7f8fe"
+source = "git+https://github.com/0pendansor/rsmpi/?branch=patch-2#bbb572024e460e99e4ee1cfda0e382640b1e32ca"
 dependencies = [
  "pkg-config",
  "shell-words",
@@ -1362,9 +1361,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libffi"
-version = "3.2.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce826c243048e3d5cec441799724de52e2d42f820468431fc3fceee2341871e2"
+checksum = "4a9434b6fc77375fb624698d5f8c49d7e80b10d59eb1219afda27d1f824d4074"
 dependencies = [
  "libc",
  "libffi-sys",
@@ -1372,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "libffi-sys"
-version = "2.3.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
+checksum = "ead36a2496acfc8edd6cc32352110e9478ac5b9b5f5b9856ebd3d28019addb84"
 dependencies = [
  "cc",
 ]
@@ -1487,8 +1486,7 @@ dependencies = [
 [[package]]
 name = "mpi"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677762a4bde2c81158fc566a69b97d11b0c3358694e64f4f922ac5189be311cc"
+source = "git+https://github.com/0pendansor/rsmpi/?branch=patch-2#bbb572024e460e99e4ee1cfda0e382640b1e32ca"
 dependencies = [
  "build-probe-mpi",
  "conv",
@@ -1502,8 +1500,7 @@ dependencies = [
 [[package]]
 name = "mpi-sys"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f35fdd7bdb38959515f008d12598065631de9624f6d42c11caef19e8e0d10de"
+source = "git+https://github.com/0pendansor/rsmpi/?branch=patch-2#bbb572024e460e99e4ee1cfda0e382640b1e32ca"
 dependencies = [
  "bindgen",
  "build-probe-mpi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,6 @@ ethnum = "1.5.0"
 rand_chacha = "0.3.1"
 derivative = "2.2.0"
 transpose = "0.2.3"
+
+[patch.crates-io]
+mpi = { git = "https://github.com/0pendansor/rsmpi/", branch = "patch-2" }

--- a/circuit/Cargo.toml
+++ b/circuit/Cargo.toml
@@ -14,10 +14,13 @@ ark-std.workspace = true
 bytes.workspace = true
 ethnum.workspace = true
 log.workspace = true
-mpi.workspace = true
+mpi = { workspace = true, optional = true }
 rand.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
 config_macros = { path = "../config_macros" }
 poly_commit = { path = "../poly_commit" }
+
+[features]
+proving = ["gkr_engine/proving", "transcript/proving", "mpi"]

--- a/circuit/src/layered/circuit.rs
+++ b/circuit/src/layered/circuit.rs
@@ -7,7 +7,7 @@ use gkr_engine::{
     root_println, ExpanderPCS, FieldEngine, GKREngine, MPIConfig, MPIEngine,
     PolynomialCommitmentType, Transcript,
 };
-use mpi::ffi::ompi_win_t;
+use mpi::ffi::MPI_Win;
 use serdes::ExpSerde;
 
 use crate::*;
@@ -168,6 +168,7 @@ impl<C: FieldEngine> Circuit<C> {
         Self::verifier_load_circuit::<Cfg>(filename)
     }
 
+    #[cfg(feature = "proving")]
     // The root process loads a circuit from a file and shares it with other processes
     // with shared memory
     // Used in the mpi case, ok if mpi_size = 1, but
@@ -176,7 +177,7 @@ impl<C: FieldEngine> Circuit<C> {
     pub fn prover_load_circuit<Cfg: GKREngine<FieldConfig = C>>(
         filename: &str,
         mpi_config: &MPIConfig,
-    ) -> (Self, *mut ompi_win_t) {
+    ) -> (Self, MPI_Win) {
         let circuit = if mpi_config.is_root() {
             let rc = RecursiveCircuit::<C>::load(filename).unwrap();
             let circuit = rc.flatten::<Cfg>();

--- a/circuit/tests/circuit_serde.rs
+++ b/circuit/tests/circuit_serde.rs
@@ -38,6 +38,7 @@ declare_gkr_config!(
     GKRScheme::Vanilla,
 );
 
+#[cfg(feature = "proving")]
 #[test]
 fn test_circuit_serde() {
     let mpi_config = MPIConfig::prover_new();

--- a/circuit/tests/shared_mem.rs
+++ b/circuit/tests/shared_mem.rs
@@ -54,6 +54,7 @@ fn load_circuit<Cfg: GKREngine>(mpi_config: &MPIConfig) -> Option<Circuit<Cfg::F
     }
 }
 
+#[cfg(feature = "proving")]
 #[test]
 fn test_shared_mem() {
     let mpi_config = MPIConfig::prover_new();
@@ -74,6 +75,7 @@ fn test_shared_mem() {
     MPIConfig::finalize();
 }
 
+#[cfg(feature = "proving")]
 #[allow(unreachable_patterns)]
 fn test_shared_mem_helper<T: SharedMemory + ExpSerde + std::fmt::Debug>(
     mpi_config: &MPIConfig,

--- a/gkr/Cargo.toml
+++ b/gkr/Cargo.toml
@@ -27,7 +27,7 @@ env_logger.workspace = true
 ethnum.workspace = true
 halo2curves.workspace = true
 log.workspace = true
-mpi.workspace = true
+mpi = {workspace = true, optional = true }
 rand.workspace = true
 rayon.workspace = true
 sha2.workspace = true
@@ -47,10 +47,12 @@ criterion.workspace = true
 [[bin]]
 name = "gkr-mpi"
 path = "src/main_mpi.rs"
+required-features = ["proving"]
 
 [[bin]]
 name = "expander-exec"
 path = "src/exec.rs"
+required-features = ["proving"]
 
 [[bin]]
 name = "dev-setup"
@@ -60,6 +62,7 @@ path = "src/utils.rs"
 default = []
 # default = [ "grinding" ]
 grinding = [ ]
+proving = ["transcript/proving", "gkr_engine/proving", "poly_commit/proving", "circuit/proving", "sumcheck/proving", "mpi"]
 recursion = [ "transcript/recursion" ]
 profile = [ "utils/profile", "sumcheck/profile" ]
 
@@ -67,4 +70,4 @@ profile = [ "utils/profile", "sumcheck/profile" ]
 name = "gkr-hashes"
 harness = false
 path = "benches/gkr_hashes.rs"
-
+required-features = ["proving"]

--- a/gkr/src/executor.rs
+++ b/gkr/src/executor.rs
@@ -17,7 +17,10 @@ use poly_commit::expander_pcs_init_testing_only;
 use serdes::{ExpSerde, SerdeError};
 use warp::{http::StatusCode, reply, Filter};
 
-use crate::{Prover, Verifier};
+#[cfg(feature = "proving")]
+use crate::Prover;
+
+use crate::Verifier;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -37,6 +40,7 @@ pub struct ExpanderExecArgs {
 
 #[derive(Debug, Subcommand, Clone)]
 pub enum ExpanderExecSubCommand {
+    #[cfg(feature = "proving")]
     Prove {
         /// Circuit File Path
         #[arg(short, long)]
@@ -67,6 +71,7 @@ pub enum ExpanderExecSubCommand {
         #[arg(short, long, default_value_t = 1)]
         mpi_size: u32,
     },
+    #[cfg(feature = "proving")]
     Serve {
         /// Circuit File Path
         #[arg(short, long)]
@@ -119,6 +124,7 @@ pub fn detect_field_type_from_circuit_file(circuit_file: &str) -> FieldType {
     }
 }
 
+#[cfg(feature = "proving")]
 pub fn prove<Cfg: GKREngine>(
     circuit: &mut Circuit<Cfg::FieldConfig>,
     mpi_config: MPIConfig,
@@ -170,6 +176,7 @@ pub async fn run_command<Cfg: GKREngine + 'static>(
     let subcommands = command.subcommands.clone();
 
     match subcommands {
+        #[cfg(feature = "proving")]
         ExpanderExecSubCommand::Prove {
             circuit_file,
             witness_file,
@@ -236,6 +243,7 @@ pub async fn run_command<Cfg: GKREngine + 'static>(
 
             println!("success");
         }
+        #[cfg(feature = "proving")]
         ExpanderExecSubCommand::Serve {
             circuit_file,
             host_ip,

--- a/gkr/src/lib.rs
+++ b/gkr/src/lib.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(target_arch = "x86_64", feature(stdarch_x86_avx512))]
 
+#[cfg(feature = "proving")]
 pub mod prover;
+#[cfg(feature = "proving")]
 pub use prover::*;
 
 pub mod verifier;

--- a/gkr/src/prover/gkr_par_verifier.rs
+++ b/gkr/src/prover/gkr_par_verifier.rs
@@ -1,3 +1,4 @@
+use crate::verifier::SumcheckLayerState;
 use circuit::Circuit;
 use gkr_engine::{
     ExpanderDualVarChallenge, ExpanderSingleVarChallenge, FieldEngine, MPIEngine, Transcript,
@@ -5,44 +6,6 @@ use gkr_engine::{
 use serdes::ExpSerde;
 use sumcheck::{sumcheck_prove_gkr_layer, ProverScratchPad};
 use utils::timer::Timer;
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct SumcheckLayerState<F: FieldEngine> {
-    pub transcript_state: Vec<u8>,
-    pub challenge: ExpanderDualVarChallenge<F>,
-    pub alpha: Option<F::ChallengeField>,
-    pub claimed_v0: F::ChallengeField,
-    pub claimed_v1: Option<F::ChallengeField>,
-}
-
-impl<F: FieldEngine> ExpSerde for SumcheckLayerState<F> {
-    const SERIALIZED_SIZE: usize = unimplemented!();
-
-    fn serialize_into<W: std::io::Write>(&self, mut writer: W) -> serdes::SerdeResult<()> {
-        self.transcript_state.serialize_into(&mut writer)?;
-        self.challenge.serialize_into(&mut writer)?;
-        self.alpha.serialize_into(&mut writer)?;
-        self.claimed_v0.serialize_into(&mut writer)?;
-        self.claimed_v1.serialize_into(&mut writer)?;
-        Ok(())
-    }
-
-    fn deserialize_from<R: std::io::Read>(mut reader: R) -> serdes::SerdeResult<Self> {
-        let transcript_state = Vec::deserialize_from(&mut reader)?;
-        let challenge = ExpanderDualVarChallenge::<F>::deserialize_from(&mut reader)?;
-        let alpha = Option::<F::ChallengeField>::deserialize_from(&mut reader)?;
-        let claimed_v0 = F::ChallengeField::deserialize_from(&mut reader)?;
-        let claimed_v1 = Option::<F::ChallengeField>::deserialize_from(&mut reader)?;
-
-        Ok(Self {
-            transcript_state,
-            challenge,
-            alpha,
-            claimed_v0,
-            claimed_v1,
-        })
-    }
-}
 
 #[allow(clippy::too_many_arguments)]
 pub fn checkpoint_sumcheck_layer_state<F: FieldEngine>(

--- a/gkr/src/tests/gkr_correctness.rs
+++ b/gkr/src/tests/gkr_correctness.rs
@@ -23,8 +23,12 @@ use serdes::ExpSerde;
 use sha2::Digest;
 use transcript::{BytesHashTranscript, FieldHashTranscript};
 
-use crate::{utils::*, Prover, Verifier};
+use crate::{utils::*, Verifier};
 
+#[cfg(feature = "proving")]
+use crate::Prover;
+
+#[cfg(feature = "proving")]
 #[test]
 fn test_gkr_correctness() {
     // Initialize logger
@@ -171,6 +175,7 @@ fn test_gkr_correctness() {
     MPIConfig::finalize();
 }
 
+#[cfg(feature = "proving")]
 #[allow(unreachable_patterns)]
 fn test_gkr_correctness_helper<Cfg: GKREngine>(write_proof_to: Option<&str>) {
     let mpi_config = MPIConfig::prover_new();

--- a/gkr/src/verifier.rs
+++ b/gkr/src/verifier.rs
@@ -27,7 +27,7 @@ mod gkr_square;
 pub use gkr_square::gkr_square_verify;
 
 mod gkr_par_verifier;
-pub use gkr_par_verifier::gkr_par_verifier_verify;
+pub use gkr_par_verifier::{gkr_par_verifier_verify, SumcheckLayerState};
 
 #[derive(Default)]
 pub struct Verifier<Cfg: GKREngine> {

--- a/gkr_engine/Cargo.toml
+++ b/gkr_engine/Cargo.toml
@@ -14,7 +14,7 @@ polynomials = { path = "../arith/polynomials"}
 serdes = { path = "../serdes" }
 
 thiserror.workspace = true
-mpi.workspace = true
+mpi = { workspace = true, optional = true }
 rand.workspace = true
 itertools.workspace = true
 
@@ -23,4 +23,5 @@ ark-std.workspace = true
 
 [features]
 default = []
+proving = ["mpi"]
 # grinding = [ "grinding" ]

--- a/gkr_engine/src/field_engine/definition.rs
+++ b/gkr_engine/src/field_engine/definition.rs
@@ -123,6 +123,7 @@ pub trait FieldEngine: Default + Debug + Clone + Send + Sync + PartialEq + 'stat
         }
     }
 
+    #[cfg(feature = "proving")]
     /// This assumes each mpi core hold their own evals, and collectively
     /// compute the global evaluation.
     /// Mostly used by the prover run with `mpiexec`

--- a/gkr_engine/src/mpi_engine/tests.rs
+++ b/gkr_engine/src/mpi_engine/tests.rs
@@ -6,6 +6,7 @@ use mersenne31::{M31Ext3, M31x16, M31};
 
 use crate::{MPIConfig, MPIEngine};
 
+#[cfg(feature = "proving")]
 fn test_gather_vec_helper(mpi_config: &MPIConfig) {
     const TEST_SIZE: usize = (1 << 10) + 1;
 
@@ -28,6 +29,7 @@ fn test_gather_vec_helper(mpi_config: &MPIConfig) {
     }
 }
 
+#[cfg(feature = "proving")]
 fn test_varlen_gather_vec_helper(mpi_config: &MPIConfig) {
     let msg: Vec<_> = (0..=mpi_config.world_rank()).collect();
     let mut global_elems: Vec<Vec<usize>> = Vec::new();
@@ -43,6 +45,7 @@ fn test_varlen_gather_vec_helper(mpi_config: &MPIConfig) {
     });
 }
 
+#[cfg(feature = "proving")]
 fn test_all_to_all_transpose_helper<F: Field>(mpi_config: &MPIConfig) {
     const TEST_MATRIX_LEN: usize = 1 << 23;
 
@@ -80,6 +83,7 @@ fn test_all_to_all_transpose_helper<F: Field>(mpi_config: &MPIConfig) {
     });
 }
 
+#[cfg(feature = "proving")]
 #[test]
 fn test_mpi_engine() {
     let mpi_config = MPIConfig::prover_new();

--- a/gkr_engine/src/poly_commit/definition.rs
+++ b/gkr_engine/src/poly_commit/definition.rs
@@ -59,6 +59,7 @@ pub trait ExpanderPCS<F: FieldEngine> {
     /// Each process returns its own scratch pad.
     fn init_scratch_pad(params: &Self::Params, mpi_engine: &impl MPIEngine) -> Self::ScratchPad;
 
+    #[cfg(feature = "proving")]
     /// Commit to a polynomial. Root process returns the commitment, other processes can return
     /// arbitrary value.
     fn commit(
@@ -69,6 +70,7 @@ pub trait ExpanderPCS<F: FieldEngine> {
         scratch_pad: &mut Self::ScratchPad,
     ) -> Option<Self::Commitment>;
 
+    #[cfg(feature = "proving")]
     /// Open the polynomial at a point.
     /// Root process returns the opening, other processes can return arbitrary value.
     ///

--- a/poly_commit/Cargo.toml
+++ b/poly_commit/Cargo.toml
@@ -41,3 +41,6 @@ harness = false
 [[bench]]
 name = "kzg"
 harness = false
+
+[features]
+proving = ["gkr_engine/proving", "transcript/proving"]

--- a/poly_commit/src/hyrax/expander_api.rs
+++ b/poly_commit/src/hyrax/expander_api.rs
@@ -50,6 +50,7 @@ where
         (hyrax_setup(*params, rng), *params)
     }
 
+    #[cfg(feature = "proving")]
     fn commit(
         _params: &Self::Params,
         mpi_engine: &impl MPIEngine,
@@ -77,6 +78,7 @@ where
         HyraxCommitment(global_commit).into()
     }
 
+    #[cfg(feature = "proving")]
     fn open(
         _params: &Self::Params,
         mpi_engine: &impl MPIEngine,

--- a/poly_commit/src/kzg/expander_api.rs
+++ b/poly_commit/src/kzg/expander_api.rs
@@ -53,6 +53,7 @@ where
         (srs, local_num_vars)
     }
 
+    #[cfg(feature = "proving")]
     fn commit(
         _params: &Self::Params,
         mpi_engine: &impl MPIEngine,
@@ -80,6 +81,7 @@ where
         KZGCommitment(final_commit).into()
     }
 
+    #[cfg(feature = "proving")]
     fn open(
         _params: &Self::Params,
         mpi_engine: &impl MPIEngine,

--- a/poly_commit/src/kzg/hyper_bikzg.rs
+++ b/poly_commit/src/kzg/hyper_bikzg.rs
@@ -14,10 +14,14 @@ use halo2curves::{
 use itertools::{chain, izip};
 use polynomials::MultilinearExtension;
 use serdes::ExpSerde;
-use transcript::{transcript_root_broadcast, transcript_verifier_sync};
+use transcript::transcript_verifier_sync;
+
+#[cfg(feature = "proving")]
+use transcript::transcript_root_broadcast;
 
 use crate::*;
 
+#[cfg(feature = "proving")]
 pub fn coeff_form_hyper_bikzg_open<E>(
     srs: &CoefFormBiKZGLocalSRS<E>,
     mpi_engine: &impl MPIEngine,

--- a/poly_commit/src/orion.rs
+++ b/poly_commit/src/orion.rs
@@ -15,7 +15,9 @@ pub use simd_field_impl::{orion_commit_simd_field, orion_open_simd_field};
 
 mod mpi_utils;
 
+#[cfg(feature = "proving")]
 mod simd_field_mpi_impl;
+#[cfg(feature = "proving")]
 pub use simd_field_mpi_impl::{orion_mpi_commit_simd_field, orion_mpi_open_simd_field};
 
 mod verify;

--- a/poly_commit/src/orion/expander_api.rs
+++ b/poly_commit/src/orion/expander_api.rs
@@ -6,11 +6,14 @@ use gkr_engine::{
 use polynomials::MultilinearExtension;
 
 use crate::orion::{
+    verify::orion_verify, OrionCommitment, OrionProof, OrionSIMDFieldPCS, OrionSRS,
+    OrionScratchPad, ORION_CODE_PARAMETER_INSTANCE,
+};
+
+#[cfg(feature = "proving")]
+use crate::orion::{
     simd_field_impl::{orion_commit_simd_field, orion_open_simd_field},
     simd_field_mpi_impl::{orion_mpi_commit_simd_field, orion_mpi_open_simd_field},
-    verify::orion_verify,
-    OrionCommitment, OrionProof, OrionSIMDFieldPCS, OrionSRS, OrionScratchPad,
-    ORION_CODE_PARAMETER_INSTANCE,
 };
 
 impl<C, ComPackF> ExpanderPCS<C>
@@ -57,7 +60,7 @@ where
     fn init_scratch_pad(_params: &Self::Params, _mpi_engine: &impl MPIEngine) -> Self::ScratchPad {
         Self::ScratchPad::default()
     }
-
+    #[cfg(feature = "proving")]
     fn commit(
         params: &Self::Params,
         mpi_engine: &impl MPIEngine,
@@ -86,6 +89,7 @@ where
         .ok()
     }
 
+    #[cfg(feature = "proving")]
     fn open(
         params: &Self::Params,
         mpi_engine: &impl MPIEngine,

--- a/poly_commit/src/orion/mpi_utils.rs
+++ b/poly_commit/src/orion/mpi_utils.rs
@@ -102,7 +102,7 @@ eventually, a final transpose each row lead to results of ordering by *WHOLE* in
 
 After all these, we can go onwards to MT commitment, and later open alphabets lies in one of the parties.
  */
-
+#[cfg(feature = "proving")]
 #[inline(always)]
 pub(crate) fn mpi_commit_encoded<PackF>(
     mpi_engine: &impl MPIEngine,
@@ -199,7 +199,7 @@ where
 
     Ok(root)
 }
-
+#[cfg(feature = "proving")]
 #[inline(always)]
 pub(crate) fn orion_mpi_mt_openings<EvalF, T>(
     mpi_engine: &impl MPIEngine,

--- a/poly_commit/src/raw.rs
+++ b/poly_commit/src/raw.rs
@@ -148,6 +148,7 @@ impl<C: FieldEngine> ExpanderPCS<C> for RawExpanderGKR<C> {
 
     fn init_scratch_pad(_params: &Self::Params, _mpi_engine: &impl MPIEngine) -> Self::ScratchPad {}
 
+    #[cfg(feature = "proving")]
     fn commit(
         params: &Self::Params,
         mpi_engine: &impl MPIEngine,
@@ -179,6 +180,7 @@ impl<C: FieldEngine> ExpanderPCS<C> for RawExpanderGKR<C> {
         Self::Commitment { evals: buffer }.into()
     }
 
+    #[cfg(feature = "proving")]
     fn open(
         _params: &Self::Params,
         _mpi_engine: &impl MPIEngine,

--- a/poly_commit/tests/common.rs
+++ b/poly_commit/tests/common.rs
@@ -44,6 +44,7 @@ pub fn test_pcs<F: ExtensionField, T: Transcript<F>, P: PolynomialCommitmentSche
     }
 }
 
+#[cfg(feature = "proving")]
 pub fn test_pcs_for_expander_gkr<
     C: FieldEngine,
     T: Transcript<C::ChallengeField>,

--- a/poly_commit/tests/test_hyrax.rs
+++ b/poly_commit/tests/test_hyrax.rs
@@ -31,6 +31,7 @@ fn test_hyrax_pcs_e2e() {
     test_hyrax_pcs_generics(3, 17)
 }
 
+#[cfg(feature = "proving")]
 fn test_hyrax_for_expander_gkr_generics(mpi_config_ref: &MPIConfig, total_num_vars: usize) {
     let mut rng = test_rng();
 
@@ -73,6 +74,7 @@ fn test_hyrax_for_expander_gkr_generics(mpi_config_ref: &MPIConfig, total_num_va
     );
 }
 
+#[cfg(feature = "proving")]
 #[test]
 fn test_hyrax_for_expander_gkr() {
     let mpi_config = MPIConfig::prover_new();

--- a/poly_commit/tests/test_kzg.rs
+++ b/poly_commit/tests/test_kzg.rs
@@ -31,6 +31,7 @@ fn test_hyperkzg_pcs_full_e2e() {
     test_hyperkzg_pcs_generics(2, 15)
 }
 
+#[cfg(feature = "proving")]
 fn test_hyper_bikzg_for_expander_gkr_generics(mpi_config_ref: &MPIConfig, total_num_vars: usize) {
     let mut rng = test_rng();
 
@@ -73,6 +74,7 @@ fn test_hyper_bikzg_for_expander_gkr_generics(mpi_config_ref: &MPIConfig, total_
     );
 }
 
+#[cfg(feature = "proving")]
 #[test]
 fn test_hyper_bikzg_for_expander_gkr() {
     let mpi_config = MPIConfig::prover_new();

--- a/poly_commit/tests/test_orion.rs
+++ b/poly_commit/tests/test_orion.rs
@@ -55,6 +55,7 @@ fn test_orion_simd_pcs_full_e2e() {
     test_orion_simd_pcs_generics::<Goldilocks, Goldilocksx8, GoldilocksExt2, Goldilocksx8>(16, 22)
 }
 
+#[cfg(feature = "proving")]
 fn test_orion_for_expander_gkr_generics<C, ComPackF, T>(
     mpi_config_ref: &MPIConfig,
     total_num_vars: usize,
@@ -115,6 +116,7 @@ fn test_orion_for_expander_gkr_generics<C, ComPackF, T>(
     );
 }
 
+#[cfg(feature = "proving")]
 #[test]
 fn test_orion_for_expander_gkr() {
     let mpi_config = MPIConfig::prover_new();

--- a/poly_commit/tests/test_raw.rs
+++ b/poly_commit/tests/test_raw.rs
@@ -30,6 +30,7 @@ fn test_raw() {
     );
 }
 
+#[cfg(feature = "proving")]
 fn test_raw_gkr_helper<C: FieldEngine, T: Transcript<C::ChallengeField>>(
     mpi_config: &MPIConfig,
     transcript: &mut T,
@@ -59,6 +60,7 @@ fn test_raw_gkr_helper<C: FieldEngine, T: Transcript<C::ChallengeField>>(
     );
 }
 
+#[cfg(feature = "proving")]
 #[test]
 fn test_raw_gkr() {
     let mpi_config = MPIConfig::prover_new();

--- a/sumcheck/Cargo.toml
+++ b/sumcheck/Cargo.toml
@@ -16,3 +16,4 @@ log.workspace = true
 
 [features]
 profile = [ "utils/profile" ]
+proving = ["gkr_engine/proving"]

--- a/sumcheck/src/lib.rs
+++ b/sumcheck/src/lib.rs
@@ -1,6 +1,7 @@
 mod sumcheck;
 pub use sumcheck::*;
 
+#[cfg(feature = "proving")]
 mod prover_helper;
 
 mod verifier_helper;

--- a/sumcheck/src/sumcheck.rs
+++ b/sumcheck/src/sumcheck.rs
@@ -4,11 +4,13 @@ use gkr_engine::{
     Transcript,
 };
 
+#[cfg(feature = "proving")]
 use crate::{
     prover_helper::{SumcheckGkrSquareHelper, SumcheckGkrVanillaHelper},
     utils::transcript_io,
-    ProverScratchPad,
 };
+
+use crate::ProverScratchPad;
 
 /// The degree of the polynomial for sumcheck, which is 2 for non-SIMD/MPI variables
 /// and 3 for SIMD/MPI variables.
@@ -19,6 +21,7 @@ pub const SUMCHECK_GKR_SIMD_MPI_DEGREE: usize = 3;
 /// It is 6 for both SIMD/MPI and non-SIMD/MPI variables.
 pub const SUMCHECK_GKR_SQUARE_DEGREE: usize = 6;
 
+#[cfg(feature = "proving")]
 // FIXME
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
@@ -91,6 +94,7 @@ pub fn sumcheck_prove_gkr_layer<F: FieldEngine, T: Transcript<F::ChallengeField>
     (vx_claim, vy_claim)
 }
 
+#[cfg(feature = "proving")]
 // FIXME
 #[allow(clippy::needless_range_loop)] // todo: remove
 #[allow(clippy::type_complexity)]

--- a/sumcheck/src/utils.rs
+++ b/sumcheck/src/utils.rs
@@ -22,6 +22,7 @@ pub fn unpack_and_combine<F: SimdField>(p: &F, coef: &[F::Scalar]) -> F::Scalar 
         .sum()
 }
 
+#[cfg(feature = "proving")]
 /// Transcript IO between sumcheck steps
 #[inline]
 pub fn transcript_io<F, T>(mpi_config: &impl MPIEngine, ps: &[F], transcript: &mut T) -> F

--- a/transcript/Cargo.toml
+++ b/transcript/Cargo.toml
@@ -17,3 +17,4 @@ mersenne31 = { path = "../arith/mersenne31/" }
 
 [features]
 recursion = []
+proving = ["gkr_engine/proving"]

--- a/transcript/src/lib.rs
+++ b/transcript/src/lib.rs
@@ -7,7 +7,9 @@ mod byte_hash_transcript;
 pub use byte_hash_transcript::BytesHashTranscript;
 
 mod transcript_utils;
-pub use transcript_utils::{transcript_root_broadcast, transcript_verifier_sync};
+#[cfg(feature = "proving")]
+pub use transcript_utils::transcript_root_broadcast;
+pub use transcript_utils::transcript_verifier_sync;
 
 #[cfg(test)]
 mod tests;

--- a/transcript/src/transcript_utils.rs
+++ b/transcript/src/transcript_utils.rs
@@ -1,6 +1,7 @@
 use arith::ExtensionField;
 use gkr_engine::{MPIEngine, Transcript};
 
+#[cfg(feature = "proving")]
 /// broadcast root transcript state. incurs an additional hash if self.world_size > 1
 pub fn transcript_root_broadcast<F>(
     transcript: &mut impl Transcript<F>,


### PR DESCRIPTION
This PR includes a version of Expander GKR module (which would be needed to verify a proof) without dependency on MPI.

Experiments only. Do not merge. 