### PR TITLE
Fix a corner case in build_eq_x_r_helper

### DIFF
--- a/arith/polynomials/src/eq.rs
+++ b/arith/polynomials/src/eq.rs
@@ -162,7 +162,7 @@ impl<F: Field> EqPolynomial<F> {
     #[inline]
     fn build_eq_x_r_helper(r: &[F], buf: &mut Vec<F>) {
         if r.is_empty() {
-            panic!("r length is 0");
+            buf.push(F::one());
         } else if r.len() == 1 {
             // initializing the buffer with [1-r_0, r_0]
             buf.push(F::one() - r[0]);


### PR DESCRIPTION
The updated behaviour now alignes with `build_eq_x_r_with_buf`.