### PR TITLE
remove MPI from PCS

### DIFF
--- a/gkr_engine/src/poly_commit/definition.rs
+++ b/gkr_engine/src/poly_commit/definition.rs
@@ -47,7 +47,7 @@ pub trait ExpanderPCS<F: FieldEngine> {
     /// rather than the base field elements.
     fn gen_srs_for_testing(
         params: &Self::Params,
-        mpi_engine: &impl MPIEngine,
+        // mpi_engine: &impl MPIEngine,
         rng: impl RngCore,
     ) -> (Self::SRS, usize);
 
@@ -63,7 +63,7 @@ pub trait ExpanderPCS<F: FieldEngine> {
     /// arbitrary value.
     fn commit(
         params: &Self::Params,
-        mpi_engine: &impl MPIEngine,
+        // mpi_engine: &impl MPIEngine,
         proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
         poly: &impl MultilinearExtension<F::SimdCircuitField>,
         scratch_pad: &mut Self::ScratchPad,
@@ -92,7 +92,7 @@ pub trait ExpanderPCS<F: FieldEngine> {
     /// argument system.
     fn open(
         params: &Self::Params,
-        mpi_engine: &impl MPIEngine,
+        // mpi_engine: &impl MPIEngine,
         proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
         poly: &impl MultilinearExtension<F::SimdCircuitField>,
         x: &ExpanderSingleVarChallenge<F>,

--- a/poly_commit/Cargo.toml
+++ b/poly_commit/Cargo.toml
@@ -48,5 +48,6 @@ name = "pcs_all"
 harness = false
 
 [features]
-default = [ "profile" ]
+default = []
+# default = [ "profile" ]
 profile = [ "utils/profile" ]

--- a/poly_commit/benches/pcs_all.rs
+++ b/poly_commit/benches/pcs_all.rs
@@ -5,7 +5,7 @@ use gkr_engine::StructuredReferenceString;
 use gkr_engine::{root_println, MPIConfig, MPIEngine, Transcript};
 use gkr_hashers::Keccak256hasher;
 use halo2curves::bn256::{Bn256, G1Affine};
-use poly_commit::{HyperKZGPCS, HyraxPCS, PolynomialCommitmentScheme};
+use poly_commit::{HyperKZGPCS, HyraxPCS, OrionBaseFieldPCS, PolynomialCommitmentScheme};
 use polynomials::MultiLinearPoly;
 use rand::RngCore;
 use serdes::ExpSerde;
@@ -15,147 +15,136 @@ use utils::timer::Timer;
 fn main() {
     let mpi_config = MPIConfig::prover_new();
     println!("==========================");
-    for num_vars in 10..19 {
+    for num_vars in 10..21 {
         root_println!(mpi_config, "num vars: {}", num_vars);
         bench_hyrax(&mpi_config, num_vars);
         bench_kzg(&mpi_config, num_vars);
+        bench_orion(&mpi_config, num_vars);
         println!("==========================");
     }
+}
+
+fn bench_orion(mpi_config: &MPIConfig, num_vars: usize) {
+    // full scalar
+    let mut rng = test_rng();
+    let (srs, _) = OrionBaseFieldPCS::<Fr, Fr, Fr, Fr>::gen_srs_for_testing(&num_vars, &mut rng);
+
+    let poly = MultiLinearPoly::<Fr>::random(num_vars, &mut rng);
+    let eval_point: Vec<_> = (0..num_vars).map(|_| Fr::random_unsafe(&mut rng)).collect();
+    pcs_bench::<OrionBaseFieldPCS<Fr, Fr, Fr, Fr>>(
+        mpi_config,
+        &num_vars,
+        &srs,
+        &poly,
+        &eval_point,
+        "orion full scalar ",
+    );
+
+    // small scalar
+    let input = (0..1 << num_vars)
+        .map(|_| Fr::from(rng.next_u32()))
+        .collect::<Vec<_>>();
+    let poly = MultiLinearPoly::<Fr>::new(input);
+    pcs_bench::<OrionBaseFieldPCS<Fr, Fr, Fr, Fr>>(
+        mpi_config,
+        &num_vars,
+        &srs,
+        &poly,
+        &eval_point,
+        "orion small scalar",
+    );
 }
 
 fn bench_hyrax(mpi_config: &MPIConfig, num_vars: usize) {
     // full scalar
     let mut rng = test_rng();
+    let (srs, _) = HyraxPCS::<G1Affine>::gen_srs_for_testing(&num_vars, &mut rng);
 
     let poly = MultiLinearPoly::<Fr>::random(num_vars, &mut rng);
-    bench_hyrax_helper(mpi_config, num_vars, &poly, "full scalar ");
+    let eval_point: Vec<_> = (0..num_vars).map(|_| Fr::random_unsafe(&mut rng)).collect();
+
+    pcs_bench::<HyraxPCS<G1Affine>>(
+        mpi_config,
+        &num_vars,
+        &srs,
+        &poly,
+        &eval_point,
+        "hyrax full scalar ",
+    );
 
     // small scalar
     let input = (0..1 << num_vars)
         .map(|_| Fr::from(rng.next_u32()))
         .collect::<Vec<_>>();
     let poly = MultiLinearPoly::<Fr>::new(input);
-    bench_hyrax_helper(mpi_config, num_vars, &poly, "small scalar");
-}
-
-fn bench_hyrax_helper(
-    mpi_config: &MPIConfig,
-    num_vars: usize,
-    poly: &MultiLinearPoly<Fr>,
-    label: &str,
-) {
-    let mut rng = test_rng();
-    let timer = Timer::new(
-        format!("{} hyrax commit    ", label).as_ref(),
-        mpi_config.is_root(),
-    );
-
-    let (srs, _) = HyraxPCS::<G1Affine>::gen_srs_for_testing(&num_vars, &mut rng);
-
-    let eval_point: Vec<_> = (0..num_vars).map(|_| Fr::random_unsafe(&mut rng)).collect();
-
-    let mut transcript = BytesHashTranscript::<Keccak256hasher>::new();
-    let mut scratch_pad = ();
-
-    let com = black_box(HyraxPCS::<G1Affine>::commit(
-        &num_vars,
-        &srs,
-        &poly,
-        &mut scratch_pad,
-    ));
-    timer.stop();
-
-    let timer = Timer::new(
-        format!("{} hyrax open      ", label).as_ref(),
-        mpi_config.is_root(),
-    );
-    let (eval, open) = black_box(HyraxPCS::<G1Affine>::open(
+    pcs_bench::<HyraxPCS<G1Affine>>(
+        mpi_config,
         &num_vars,
         &srs,
         &poly,
         &eval_point,
-        &scratch_pad,
-        &mut transcript,
-    ));
-    timer.stop();
-
-    let timer = Timer::new(
-        format!("{} hyrax verify    ", label).as_ref(),
-        mpi_config.is_root(),
+        "hyrax small scalar",
     );
-    let mut transcript = BytesHashTranscript::<Keccak256hasher>::new();
-    assert!(black_box(HyraxPCS::<G1Affine>::verify(
-        &num_vars,
-        &srs,
-        &com,
-        &eval_point,
-        eval,
-        &open,
-        &mut transcript,
-    )));
-    timer.stop();
-
-    let mut buf = vec![];
-    com.serialize_into(&mut buf).unwrap();
-    let com_size = buf.len();
-
-    let mut buf = vec![];
-    open.serialize_into(&mut buf).unwrap();
-    let open_size = buf.len();
-
-    root_println!(mpi_config, "hyrax com size       {}", com_size);
-    root_println!(mpi_config, "hyrax open size      {}", open_size);
-
-    root_println!(mpi_config, "  --- ");
 }
 
 fn bench_kzg(mpi_config: &MPIConfig, num_vars: usize) {
     // full scalar
     let mut rng = test_rng();
+    let (srs, _) = HyperKZGPCS::<Bn256>::gen_srs_for_testing(&num_vars, &mut rng);
 
     let poly = MultiLinearPoly::<Fr>::random(num_vars, &mut rng);
-    bench_kzg_helper(mpi_config, num_vars, &poly, "full scalar ");
+    let eval_point: Vec<_> = (0..num_vars).map(|_| Fr::random_unsafe(&mut rng)).collect();
+
+    pcs_bench::<HyperKZGPCS<Bn256>>(
+        mpi_config,
+        &num_vars,
+        &srs,
+        &poly,
+        &eval_point,
+        "kzg full scalar   ",
+    );
 
     // small scalar
     let input = (0..1 << num_vars)
         .map(|_| Fr::from(rng.next_u32()))
         .collect::<Vec<_>>();
     let poly = MultiLinearPoly::<Fr>::new(input);
-    bench_kzg_helper(mpi_config, num_vars, &poly, "small scalar");
+    pcs_bench::<HyperKZGPCS<Bn256>>(
+        mpi_config,
+        &num_vars,
+        &srs,
+        &poly,
+        &eval_point,
+        "kzg small scalar  ",
+    );
 }
 
-fn bench_kzg_helper(
+fn pcs_bench<PCS: PolynomialCommitmentScheme<Fr>>(
     mpi_config: &MPIConfig,
-    num_vars: usize,
-    poly: &MultiLinearPoly<Fr>,
+    num_vars: &PCS::Params,
+    srs: &PCS::SRS,
+    poly: &PCS::Poly,
+    eval_point: &PCS::EvalPoint,
     label: &str,
 ) {
-    let mut rng = test_rng();
-
-    let (srs, _) = HyperKZGPCS::<Bn256>::gen_srs_for_testing(&num_vars, &mut rng);
-    let (pk, vk) = srs.clone().into_keys();
-    let eval_point: Vec<_> = (0..num_vars).map(|_| Fr::random_unsafe(&mut rng)).collect();
-
-    let mut transcript = BytesHashTranscript::<Keccak256hasher>::new();
-    let mut scratch_pad = HyperKZGPCS::<Bn256>::init_scratch_pad(&num_vars);
-
     let timer = Timer::new(
-        format!("{} kzg commit      ", label).as_ref(),
+        format!("{} commit    ", label).as_ref(),
         mpi_config.is_root(),
     );
-    let com = black_box(HyperKZGPCS::<Bn256>::commit(
-        &num_vars,
-        &pk,
-        &poly,
-        &mut scratch_pad,
-    ));
+
+    let (pk, vk) = srs.clone().into_keys();
+
+    let mut transcript = BytesHashTranscript::<Keccak256hasher>::new();
+    let mut scratch_pad = PCS::init_scratch_pad(&num_vars);
+
+    let com = black_box(PCS::commit(&num_vars, &pk, &poly, &mut scratch_pad));
     timer.stop();
 
     let timer = Timer::new(
-        format!("{} kzg open        ", label).as_ref(),
+        format!("{} open      ", label).as_ref(),
         mpi_config.is_root(),
     );
-    let (eval, open) = black_box(HyperKZGPCS::<Bn256>::open(
+    let (eval, open) = black_box(PCS::open(
         &num_vars,
         &pk,
         &poly,
@@ -166,11 +155,11 @@ fn bench_kzg_helper(
     timer.stop();
 
     let timer = Timer::new(
-        format!("{} kzg verify      ", label).as_ref(),
+        format!("{} verify    ", label).as_ref(),
         mpi_config.is_root(),
     );
     let mut transcript = BytesHashTranscript::<Keccak256hasher>::new();
-    assert!(black_box(HyperKZGPCS::<Bn256>::verify(
+    assert!(black_box(PCS::verify(
         &num_vars,
         &vk,
         &com,
@@ -189,8 +178,16 @@ fn bench_kzg_helper(
     open.serialize_into(&mut buf).unwrap();
     let open_size = buf.len();
 
-    root_println!(mpi_config, "kzg com size         {}", com_size);
-    root_println!(mpi_config, "kzg open size        {}", open_size);
+    root_println!(
+        mpi_config,
+        "{}",
+        format!("{} commit size    {}", label, com_size),
+    );
+    root_println!(
+        mpi_config,
+        "{}",
+        format!("{} open size      {}", label, open_size),
+    );
 
     root_println!(mpi_config, "  --- ");
 }

--- a/poly_commit/benches/pcs_all.rs
+++ b/poly_commit/benches/pcs_all.rs
@@ -15,10 +15,10 @@ use utils::timer::Timer;
 fn main() {
     let mpi_config = MPIConfig::prover_new();
     println!("==========================");
-    for num_vars in 10..21 {
+    for num_vars in 10..11 {
         root_println!(mpi_config, "num vars: {}", num_vars);
-        bench_hyrax(&mpi_config, num_vars);
         bench_kzg(&mpi_config, num_vars);
+        bench_hyrax(&mpi_config, num_vars);
         bench_orion(&mpi_config, num_vars);
         println!("==========================");
     }
@@ -88,22 +88,10 @@ fn bench_hyrax(mpi_config: &MPIConfig, num_vars: usize) {
 }
 
 fn bench_kzg(mpi_config: &MPIConfig, num_vars: usize) {
-    // full scalar
     let mut rng = test_rng();
     let (srs, _) = HyperKZGPCS::<Bn256>::gen_srs_for_testing(&num_vars, &mut rng);
 
-    let poly = MultiLinearPoly::<Fr>::random(num_vars, &mut rng);
     let eval_point: Vec<_> = (0..num_vars).map(|_| Fr::random_unsafe(&mut rng)).collect();
-
-    pcs_bench::<HyperKZGPCS<Bn256>>(
-        mpi_config,
-        &num_vars,
-        &srs,
-        &poly,
-        &eval_point,
-        "kzg full scalar   ",
-    );
-
     // small scalar
     let input = (0..1 << num_vars)
         .map(|_| Fr::from(rng.next_u32()))
@@ -116,6 +104,16 @@ fn bench_kzg(mpi_config: &MPIConfig, num_vars: usize) {
         &poly,
         &eval_point,
         "kzg small scalar  ",
+    );
+    // full scalar
+    let poly = MultiLinearPoly::<Fr>::random(num_vars, &mut rng);
+    pcs_bench::<HyperKZGPCS<Bn256>>(
+        mpi_config,
+        &num_vars,
+        &srs,
+        &poly,
+        &eval_point,
+        "kzg full scalar   ",
     );
 }
 

--- a/poly_commit/src/kzg/bivariate.rs
+++ b/poly_commit/src/kzg/bivariate.rs
@@ -89,8 +89,8 @@ where
 
     let (div, eval) = univariate_degree_one_quotient(&gammas, beta);
 
-    let mut y_open = E::G1::generator() * E::Fr::ZERO;
-    msm::multiexp_serial(&div, &srs.tau_y_srs.powers_of_tau[..div.len()], &mut y_open);
+    // let mut y_open = E::G1::generator() * E::Fr::ZERO;
+let y_open =     msm::best_multiexp(&div, &srs.tau_y_srs.powers_of_tau[..div.len()],);
 
     (
         eval,

--- a/poly_commit/src/kzg/expander_api.rs
+++ b/poly_commit/src/kzg/expander_api.rs
@@ -39,14 +39,14 @@ where
 
     fn gen_srs_for_testing(
         params: &Self::Params,
-        mpi_engine: &impl MPIEngine,
+        // mpi_engine: &impl MPIEngine,
         rng: impl rand::RngCore,
     ) -> (Self::SRS, usize) {
         let local_num_vars = if *params == 0 { 1 } else { *params };
 
         let x_degree_po2 = 1 << local_num_vars;
-        let y_degree_po2 = mpi_engine.world_size();
-        let rank = mpi_engine.world_rank();
+        let y_degree_po2 = 1; //mpi_engine.world_size();
+        let rank = 0; // mpi_engine.world_rank();
 
         let srs =
             generate_coef_form_bi_kzg_local_srs_for_testing(x_degree_po2, y_degree_po2, rank, rng);
@@ -55,7 +55,7 @@ where
 
     fn commit(
         _params: &Self::Params,
-        mpi_engine: &impl MPIEngine,
+        // mpi_engine: &impl MPIEngine,
         proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
         poly: &impl polynomials::MultilinearExtension<<G as FieldEngine>::SimdCircuitField>,
         _scratch_pad: &mut Self::ScratchPad,
@@ -63,26 +63,26 @@ where
         let local_commitment =
             coeff_form_uni_kzg_commit(&proving_key.tau_x_srs, poly.hypercube_basis_ref());
 
-        if mpi_engine.is_single_process() {
-            return KZGCommitment(local_commitment).into();
-        }
+        // if mpi_engine.is_single_process() {
+        return KZGCommitment(local_commitment).into();
+        // }
 
-        let local_g1 = local_commitment.to_curve();
-        let mut root_gathering_commits: Vec<E::G1> = vec![local_g1; mpi_engine.world_size()];
-        mpi_engine.gather_vec(&[local_g1], &mut root_gathering_commits);
+        // let local_g1 = local_commitment.to_curve();
+        // let mut root_gathering_commits: Vec<E::G1> = vec![local_g1; mpi_engine.world_size()];
+        // mpi_engine.gather_vec(&[local_g1], &mut root_gathering_commits);
 
-        if !mpi_engine.is_root() {
-            return None;
-        }
+        // if !mpi_engine.is_root() {
+        //     return None;
+        // }
 
-        let final_commit = root_gathering_commits.iter().sum::<E::G1>().into();
+        // let final_commit = root_gathering_commits.iter().sum::<E::G1>().into();
 
-        KZGCommitment(final_commit).into()
+        // KZGCommitment(final_commit).into()
     }
 
     fn open(
         _params: &Self::Params,
-        mpi_engine: &impl MPIEngine,
+        // mpi_engine: &impl MPIEngine,
         proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
         poly: &impl polynomials::MultilinearExtension<<G as FieldEngine>::SimdCircuitField>,
         x: &ExpanderSingleVarChallenge<G>,
@@ -91,10 +91,10 @@ where
     ) -> Option<Self::Opening> {
         coeff_form_hyper_bikzg_open(
             proving_key,
-            mpi_engine,
+            // mpi_engine,
             poly,
             &x.local_xs(),
-            &x.r_mpi,
+            // &x.r_mpi,
             transcript,
         )
     }

--- a/poly_commit/src/kzg/hyper_bikzg.rs
+++ b/poly_commit/src/kzg/hyper_bikzg.rs
@@ -20,10 +20,10 @@ use crate::*;
 
 pub fn coeff_form_hyper_bikzg_open<E>(
     srs: &CoefFormBiKZGLocalSRS<E>,
-    mpi_engine: &impl MPIEngine,
+    // mpi_engine: &impl MPIEngine,
     coeffs: &impl MultilinearExtension<E::Fr>,
     local_alphas: &[E::Fr],
-    mpi_alphas: &[E::Fr],
+    // mpi_alphas: &[E::Fr],
     fs_transcript: &mut impl Transcript,
 ) -> Option<HyperBiKZGOpening<E>>
 where
@@ -34,412 +34,413 @@ where
 {
     // NOTE(HS) deteriorate to vanilla HyperKZG if mpi_alphas is empty, namely single party setting
     // since there is no other mpi variables, then the party running is the leader
-    if mpi_alphas.is_empty() {
-        let (_, hyperkzg_opening) = coeff_form_uni_hyperkzg_open(
-            &srs.tau_x_srs,
-            coeffs.hypercube_basis_ref(),
-            local_alphas,
-            fs_transcript,
-        );
-
-        let hyper_bikzg_opening: HyperBiKZGOpening<E> = hyperkzg_opening.into();
-        return hyper_bikzg_opening.into();
-    }
-
-    //
-    // Locally fold local variables, then commit to construct the poly oracles
-    //
-
-    let (local_folded_x_oracle_commits, local_folded_x_oracle_coeffs) =
-        coeff_form_hyperkzg_local_poly_oracles(
-            &srs.tau_x_srs,
-            coeffs.hypercube_basis_ref(),
-            local_alphas,
-        );
-
-    let local_final_eval_at_x = {
-        let last_coeffs = local_folded_x_oracle_coeffs.last().unwrap().clone();
-        let last_alpha = local_alphas[local_alphas.len() - 1];
-        (E::Fr::ONE - last_alpha) * last_coeffs[0] + last_alpha * last_coeffs[1]
-    };
-
-    //
-    // Leader party gathering evals and oracle commitments
-    //
-
-    let mut root_gathering_folded_oracle_commits: Vec<E::G1Affine> =
-        vec![E::G1Affine::default(); mpi_engine.world_size() * local_folded_x_oracle_commits.len()];
-    let mut final_evals_at_x: Vec<E::Fr> = vec![E::Fr::ZERO; mpi_engine.world_size()];
-
-    mpi_engine.gather_vec(
-        &local_folded_x_oracle_commits,
-        &mut root_gathering_folded_oracle_commits,
-    );
-    mpi_engine.gather_vec(&[local_final_eval_at_x], &mut final_evals_at_x);
-
-    //
-    // Leader party collect oracle commitments, sum them up for folded oracles
-    //
-
-    let mut folded_x_oracle_commits: Vec<E::G1Affine> = Vec::new();
-    let mut y_oracle_commit: E::G1Affine = E::G1Affine::default();
-
-    if mpi_engine.is_root() {
-        let g1_zero = E::G1Affine::default().to_curve();
-        let mut folded_x_coms_g1 = vec![g1_zero; local_folded_x_oracle_commits.len()];
-
-        root_gathering_folded_oracle_commits
-            .chunks(local_folded_x_oracle_commits.len())
-            .for_each(|folded_oracles| {
-                izip!(&mut folded_x_coms_g1, folded_oracles)
-                    .for_each(|(x_com_i, oracle_i)| *x_com_i += oracle_i.to_curve())
-            });
-
-        folded_x_oracle_commits = vec![E::G1Affine::default(); folded_x_coms_g1.len()];
-        E::G1::batch_normalize(&folded_x_coms_g1, &mut folded_x_oracle_commits);
-
-        y_oracle_commit = coeff_form_uni_kzg_commit(&srs.tau_y_srs, &final_evals_at_x);
-    }
-
-    //
-    // The leader party continues on folding over "final_evals" over only y variables.
-    //
-
-    let mut folded_y_oracle_commits: Vec<E::G1Affine> = Vec::new();
-    let mut folded_y_oracle_coeffs: Vec<Vec<E::Fr>> = Vec::new();
-
-    if mpi_engine.is_root() {
-        (folded_y_oracle_commits, folded_y_oracle_coeffs) =
-            coeff_form_hyperkzg_local_poly_oracles(&srs.tau_y_srs, &final_evals_at_x, mpi_alphas);
-    }
-
-    //
-    // The leader party feeds all folded oracles into RO, then sync party's transcript state
-    //
-
-    let mut folded_oracle_commitments: Vec<E::G1Affine> = Vec::new();
-
-    if mpi_engine.is_root() {
-        folded_oracle_commitments = {
-            let mut temp = folded_x_oracle_commits.clone();
-            temp.push(y_oracle_commit);
-            temp.extend_from_slice(&folded_y_oracle_commits);
-            temp
-        };
-
-        chain!(
-            &folded_x_oracle_commits,
-            iter::once(&y_oracle_commit),
-            &folded_y_oracle_commits,
-        )
-        .for_each(|f| fs_transcript.append_u8_slice(f.to_bytes().as_ref()));
-    }
-
-    transcript_root_broadcast(fs_transcript, mpi_engine);
-
-    let beta_x = fs_transcript.generate_field_element::<E::Fr>();
-    let beta_y = fs_transcript.generate_field_element::<E::Fr>();
-
-    //
-    // Local parties run HyperKZG evals at beta_x, -beta_x, beta_x^2 over folded coeffs
-    //
-
-    let local_folded_x_evals: HyperKZGLocalEvals<E> = coeff_form_hyperkzg_local_evals(
+    // if mpi_alphas.is_empty() {
+    let (_, hyperkzg_opening) = coeff_form_uni_hyperkzg_open(
+        &srs.tau_x_srs,
         coeffs.hypercube_basis_ref(),
-        &local_folded_x_oracle_coeffs,
         local_alphas,
-        beta_x,
+        fs_transcript,
     );
 
-    let local_exported_folded_x_evals: HyperKZGExportedLocalEvals<E> =
-        local_folded_x_evals.clone().into();
+    let hyper_bikzg_opening: HyperBiKZGOpening<E> = hyperkzg_opening.into();
+    return hyper_bikzg_opening.into();
+    // }
 
-    //
-    // Collect all exported local folded evals at x to the leader party
-    //
+    // //
+    // // Locally fold local variables, then commit to construct the poly oracles
+    // //
 
-    let mut root_gathering_exported_folded_x_evals: Vec<HyperKZGExportedLocalEvals<E>> =
-        vec![local_exported_folded_x_evals.clone(); mpi_engine.world_size()];
-    let mut root_aggregated_x_evals = HyperKZGAggregatedEvals::<E>::default();
-    let mut root_folded_y_evals = HyperKZGLocalEvals::<E>::default();
+    // let (local_folded_x_oracle_commits, local_folded_x_oracle_coeffs) =
+    //     coeff_form_hyperkzg_local_poly_oracles(
+    //         &srs.tau_x_srs,
+    //         coeffs.hypercube_basis_ref(),
+    //         local_alphas,
+    //     );
 
-    {
-        let mut local_exported_folded_x_evals_bytes: Vec<u8> = Vec::new();
-        local_exported_folded_x_evals
-            .serialize_into(&mut local_exported_folded_x_evals_bytes)
-            .unwrap();
+    // let local_final_eval_at_x = {
+    //     let last_coeffs = local_folded_x_oracle_coeffs.last().unwrap().clone();
+    //     let last_alpha = local_alphas[local_alphas.len() - 1];
+    //     (E::Fr::ONE - last_alpha) * last_coeffs[0] + last_alpha * last_coeffs[1]
+    // };
 
-        let mut gathering_buffer =
-            vec![0u8; mpi_engine.world_size() * local_exported_folded_x_evals_bytes.len()];
+    // //
+    // // Leader party gathering evals and oracle commitments
+    // //
 
-        mpi_engine.gather_vec(&local_exported_folded_x_evals_bytes, &mut gathering_buffer);
+    // let mut root_gathering_folded_oracle_commits: Vec<E::G1Affine> =
+    //     vec![E::G1Affine::default(); mpi_engine.world_size() *
+    // local_folded_x_oracle_commits.len()]; let mut final_evals_at_x: Vec<E::Fr> =
+    // vec![E::Fr::ZERO; mpi_engine.world_size()];
 
-        if mpi_engine.is_root() {
-            izip!(
-                &mut root_gathering_exported_folded_x_evals,
-                gathering_buffer.chunks(local_exported_folded_x_evals_bytes.len())
-            )
-            .for_each(|(es, bs)| {
-                let mut cursor = Cursor::new(bs.to_vec());
-                *es = HyperKZGExportedLocalEvals::<E>::deserialize_from(&mut cursor).unwrap();
-            })
-        }
-    }
+    // mpi_engine.gather_vec(
+    //     &local_folded_x_oracle_commits,
+    //     &mut root_gathering_folded_oracle_commits,
+    // );
+    // mpi_engine.gather_vec(&[local_final_eval_at_x], &mut final_evals_at_x);
 
-    //
-    // Leader aggregates all local exported evaluations (at x) by evaluating at y
-    // by three points: beta_y, -beta_y, beta_y^2, then fold the final evals at x,
-    // which is degree 0 for variable x, along variable y.
-    //
+    // //
+    // // Leader party collect oracle commitments, sum them up for folded oracles
+    // //
 
-    if mpi_engine.is_root() {
-        root_aggregated_x_evals = HyperKZGAggregatedEvals::new_from_exported_evals(
-            &root_gathering_exported_folded_x_evals,
-            beta_y,
-        );
+    // let mut folded_x_oracle_commits: Vec<E::G1Affine> = Vec::new();
+    // let mut y_oracle_commit: E::G1Affine = E::G1Affine::default();
 
-        root_folded_y_evals = coeff_form_hyperkzg_local_evals(
-            &final_evals_at_x,
-            &folded_y_oracle_coeffs,
-            mpi_alphas,
-            beta_y,
-        );
-    }
+    // if mpi_engine.is_root() {
+    //     let g1_zero = E::G1Affine::default().to_curve();
+    //     let mut folded_x_coms_g1 = vec![g1_zero; local_folded_x_oracle_commits.len()];
 
-    //
-    // The leader party feeds all evals into RO, then sync party's transcript state
-    //
+    //     root_gathering_folded_oracle_commits
+    //         .chunks(local_folded_x_oracle_commits.len())
+    //         .for_each(|folded_oracles| {
+    //             izip!(&mut folded_x_coms_g1, folded_oracles)
+    //                 .for_each(|(x_com_i, oracle_i)| *x_com_i += oracle_i.to_curve())
+    //         });
 
-    if mpi_engine.is_root() {
-        root_aggregated_x_evals.append_to_transcript(fs_transcript);
-        root_folded_y_evals.append_to_transcript(fs_transcript);
-    }
+    //     folded_x_oracle_commits = vec![E::G1Affine::default(); folded_x_coms_g1.len()];
+    //     E::G1::batch_normalize(&folded_x_coms_g1, &mut folded_x_oracle_commits);
 
-    transcript_root_broadcast(fs_transcript, mpi_engine);
+    //     y_oracle_commit = coeff_form_uni_kzg_commit(&srs.tau_y_srs, &final_evals_at_x);
+    // }
 
-    let gamma = fs_transcript.generate_field_element::<E::Fr>();
+    // //
+    // // The leader party continues on folding over "final_evals" over only y variables.
+    // //
 
-    //
-    // The leader party linear combines folded coeffs at y with gamma,
-    // then broadcast the coeffs back to local.
-    //
+    // let mut folded_y_oracle_commits: Vec<E::G1Affine> = Vec::new();
+    // let mut folded_y_oracle_coeffs: Vec<Vec<E::Fr>> = Vec::new();
 
-    let mut leader_gamma_aggregated_y_coeffs: Vec<E::Fr> =
-        vec![E::Fr::ZERO; mpi_engine.world_size()];
+    // if mpi_engine.is_root() {
+    //     (folded_y_oracle_commits, folded_y_oracle_coeffs) =
+    //         coeff_form_hyperkzg_local_poly_oracles(&srs.tau_y_srs, &final_evals_at_x,
+    // mpi_alphas); }
 
-    if mpi_engine.is_root() {
-        leader_gamma_aggregated_y_coeffs = {
-            let gamma_n = gamma.pow_vartime([local_alphas.len() as u64]);
-            let mut temp = coeff_form_hyperkzg_local_oracle_polys_aggregate::<E>(
-                &final_evals_at_x,
-                &folded_y_oracle_coeffs,
-                gamma,
-            );
-            temp.iter_mut().for_each(|t| *t *= gamma_n);
-            temp
-        };
-    }
+    // //
+    // // The leader party feeds all folded oracles into RO, then sync party's transcript state
+    // //
 
-    // TODO(HS) can be improved to broadcast a vec, returning a coeff to each party
-    {
-        let mut serialized_y_coeffs: Vec<u8> = Vec::new();
-        leader_gamma_aggregated_y_coeffs
-            .serialize_into(&mut serialized_y_coeffs)
-            .unwrap();
+    // let mut folded_oracle_commitments: Vec<E::G1Affine> = Vec::new();
 
-        mpi_engine.root_broadcast_bytes(&mut serialized_y_coeffs);
-        leader_gamma_aggregated_y_coeffs = {
-            let mut cursor = Cursor::new(serialized_y_coeffs);
-            Vec::deserialize_from(&mut cursor).unwrap()
-        };
-    }
+    // if mpi_engine.is_root() {
+    //     folded_oracle_commitments = {
+    //         let mut temp = folded_x_oracle_commits.clone();
+    //         temp.push(y_oracle_commit);
+    //         temp.extend_from_slice(&folded_y_oracle_commits);
+    //         temp
+    //     };
 
-    //
-    // Local party compute the linear combined folded coeffs at x with gamma,
-    // then the degree2 Lagrange over beta_x, -beta_x, beta_x^2,
-    // then vanish the local aggregated x coeffs at the three points above,
-    // and commit to the final quotient poly
-    //
+    //     chain!(
+    //         &folded_x_oracle_commits,
+    //         iter::once(&y_oracle_commit),
+    //         &folded_y_oracle_commits,
+    //     )
+    //     .for_each(|f| fs_transcript.append_u8_slice(f.to_bytes().as_ref()));
+    // }
 
-    let mut local_gamma_aggregated_x_coeffs = {
-        let mut f_gamma_local = coeff_form_hyperkzg_local_oracle_polys_aggregate::<E>(
-            coeffs.hypercube_basis_ref(),
-            &local_folded_x_oracle_coeffs,
-            gamma,
-        );
+    // transcript_root_broadcast(fs_transcript, mpi_engine);
 
-        f_gamma_local[0] += leader_gamma_aggregated_y_coeffs[mpi_engine.world_rank()];
-        f_gamma_local
-    };
+    // let beta_x = fs_transcript.generate_field_element::<E::Fr>();
+    // let beta_y = fs_transcript.generate_field_element::<E::Fr>();
 
-    let local_lagrange_degree2_at_x = {
-        let mut local_degree_2 =
-            local_folded_x_evals.interpolate_degree2_aggregated_evals(beta_x, gamma);
+    // //
+    // // Local parties run HyperKZG evals at beta_x, -beta_x, beta_x^2 over folded coeffs
+    // //
 
-        local_degree_2[0] += leader_gamma_aggregated_y_coeffs[mpi_engine.world_rank()];
-        local_degree_2
-    };
+    // let local_folded_x_evals: HyperKZGLocalEvals<E> = coeff_form_hyperkzg_local_evals(
+    //     coeffs.hypercube_basis_ref(),
+    //     &local_folded_x_oracle_coeffs,
+    //     local_alphas,
+    //     beta_x,
+    // );
 
-    let local_gamma_aggregated_x_quotient = {
-        let mut nom = local_gamma_aggregated_x_coeffs.clone();
-        polynomial_add(&mut nom, -E::Fr::ONE, &local_lagrange_degree2_at_x);
-        univariate_roots_quotient(nom, &[beta_x, -beta_x, beta_x * beta_x])
-    };
+    // let local_exported_folded_x_evals: HyperKZGExportedLocalEvals<E> =
+    //     local_folded_x_evals.clone().into();
 
-    let local_gamma_aggregated_x_quotient_commitment_g1: E::G1 =
-        coeff_form_uni_kzg_commit(&srs.tau_x_srs, &local_gamma_aggregated_x_quotient).to_curve();
+    // //
+    // // Collect all exported local folded evals at x to the leader party
+    // //
 
-    //
-    // Leader collect all the quotient commitment at x, sum it up and feed it to RO,
-    // then sync transcript state
-    //
+    // let mut root_gathering_exported_folded_x_evals: Vec<HyperKZGExportedLocalEvals<E>> =
+    //     vec![local_exported_folded_x_evals.clone(); mpi_engine.world_size()];
+    // let mut root_aggregated_x_evals = HyperKZGAggregatedEvals::<E>::default();
+    // let mut root_folded_y_evals = HyperKZGLocalEvals::<E>::default();
 
-    let mut root_gathering_gamma_aggregated_x_quotient_commitment_g1s: Vec<E::G1> =
-        vec![E::G1::generator(); mpi_engine.world_size()];
-    mpi_engine.gather_vec(
-        &[local_gamma_aggregated_x_quotient_commitment_g1],
-        &mut root_gathering_gamma_aggregated_x_quotient_commitment_g1s,
-    );
+    // {
+    //     let mut local_exported_folded_x_evals_bytes: Vec<u8> = Vec::new();
+    //     local_exported_folded_x_evals
+    //         .serialize_into(&mut local_exported_folded_x_evals_bytes)
+    //         .unwrap();
 
-    let mut gamma_aggregated_x_quotient_commitment: E::G1Affine = E::G1Affine::default();
+    //     let mut gathering_buffer =
+    //         vec![0u8; mpi_engine.world_size() * local_exported_folded_x_evals_bytes.len()];
 
-    if mpi_engine.is_root() {
-        gamma_aggregated_x_quotient_commitment =
-            root_gathering_gamma_aggregated_x_quotient_commitment_g1s
-                .iter()
-                .sum::<E::G1>()
-                .to_affine();
+    //     mpi_engine.gather_vec(&local_exported_folded_x_evals_bytes, &mut gathering_buffer);
 
-        fs_transcript.append_u8_slice(gamma_aggregated_x_quotient_commitment.to_bytes().as_ref());
-    }
+    //     if mpi_engine.is_root() {
+    //         izip!(
+    //             &mut root_gathering_exported_folded_x_evals,
+    //             gathering_buffer.chunks(local_exported_folded_x_evals_bytes.len())
+    //         )
+    //         .for_each(|(es, bs)| {
+    //             let mut cursor = Cursor::new(bs.to_vec());
+    //             *es = HyperKZGExportedLocalEvals::<E>::deserialize_from(&mut cursor).unwrap();
+    //         })
+    //     }
+    // }
 
-    transcript_root_broadcast(fs_transcript, mpi_engine);
+    // //
+    // // Leader aggregates all local exported evaluations (at x) by evaluating at y
+    // // by three points: beta_y, -beta_y, beta_y^2, then fold the final evals at x,
+    // // which is degree 0 for variable x, along variable y.
+    // //
 
-    let delta_x = fs_transcript.generate_field_element::<E::Fr>();
+    // if mpi_engine.is_root() {
+    //     root_aggregated_x_evals = HyperKZGAggregatedEvals::new_from_exported_evals(
+    //         &root_gathering_exported_folded_x_evals,
+    //         beta_y,
+    //     );
 
-    //
-    // Locally compute the Lagrange-degree2 interpolation at delta_x, pool at leader
-    //
+    //     root_folded_y_evals = coeff_form_hyperkzg_local_evals(
+    //         &final_evals_at_x,
+    //         &folded_y_oracle_coeffs,
+    //         mpi_alphas,
+    //         beta_y,
+    //     );
+    // }
 
-    let mut degree2_evals_at_delta_x: Vec<E::Fr> = vec![E::Fr::ZERO; mpi_engine.world_size()];
+    // //
+    // // The leader party feeds all evals into RO, then sync party's transcript state
+    // //
 
-    let local_degree2_eval_at_delta_x = local_lagrange_degree2_at_x[0]
-        + local_lagrange_degree2_at_x[1] * delta_x
-        + local_lagrange_degree2_at_x[2] * delta_x * delta_x;
+    // if mpi_engine.is_root() {
+    //     root_aggregated_x_evals.append_to_transcript(fs_transcript);
+    //     root_folded_y_evals.append_to_transcript(fs_transcript);
+    // }
 
-    mpi_engine.gather_vec(
-        &[local_degree2_eval_at_delta_x],
-        &mut degree2_evals_at_delta_x,
-    );
+    // transcript_root_broadcast(fs_transcript, mpi_engine);
 
-    //
-    // Leader does similar thing - quotient at beta_y, -beta_y, beta_y^2,
-    // commit the quotient polynomial commitment at y, feed it to RO,
-    // then sync transcript state
-    //
+    // let gamma = fs_transcript.generate_field_element::<E::Fr>();
 
-    let mut leader_quotient_y_coeffs: Vec<E::Fr> = vec![E::Fr::ZERO; mpi_engine.world_size()];
-    let mut leader_quotient_y_commitment: E::G1Affine = E::G1Affine::default();
+    // //
+    // // The leader party linear combines folded coeffs at y with gamma,
+    // // then broadcast the coeffs back to local.
+    // //
 
-    if mpi_engine.is_root() {
-        let num_y_coeffs = mpi_engine.world_size();
+    // let mut leader_gamma_aggregated_y_coeffs: Vec<E::Fr> =
+    //     vec![E::Fr::ZERO; mpi_engine.world_size()];
 
-        // NOTE(HS) interpolate at beta_y, beta_y2, -beta_y on lagrange_degree2_delta_x
-        let lagrange_degree2_delta_y = {
-            let pos_beta_y_pow_series = powers_series(&beta_y, num_y_coeffs);
-            let neg_beta_y_pow_series = powers_series(&(-beta_y), num_y_coeffs);
-            let beta_y2_pow_series = powers_series(&(beta_y * beta_y), num_y_coeffs);
+    // if mpi_engine.is_root() {
+    //     leader_gamma_aggregated_y_coeffs = {
+    //         let gamma_n = gamma.pow_vartime([local_alphas.len() as u64]);
+    //         let mut temp = coeff_form_hyperkzg_local_oracle_polys_aggregate::<E>(
+    //             &final_evals_at_x,
+    //             &folded_y_oracle_coeffs,
+    //             gamma,
+    //         );
+    //         temp.iter_mut().for_each(|t| *t *= gamma_n);
+    //         temp
+    //     };
+    // }
 
-            let at_beta_y = univariate_evaluate(&degree2_evals_at_delta_x, &pos_beta_y_pow_series);
-            let at_neg_beta_y =
-                univariate_evaluate(&degree2_evals_at_delta_x, &neg_beta_y_pow_series);
-            let at_beta_y2 = univariate_evaluate(&degree2_evals_at_delta_x, &beta_y2_pow_series);
+    // // TODO(HS) can be improved to broadcast a vec, returning a coeff to each party
+    // {
+    //     let mut serialized_y_coeffs: Vec<u8> = Vec::new();
+    //     leader_gamma_aggregated_y_coeffs
+    //         .serialize_into(&mut serialized_y_coeffs)
+    //         .unwrap();
 
-            coeff_form_degree2_lagrange(
-                [beta_y, -beta_y, beta_y * beta_y],
-                [at_beta_y, at_neg_beta_y, at_beta_y2],
-            )
-        };
+    //     mpi_engine.root_broadcast_bytes(&mut serialized_y_coeffs);
+    //     leader_gamma_aggregated_y_coeffs = {
+    //         let mut cursor = Cursor::new(serialized_y_coeffs);
+    //         Vec::deserialize_from(&mut cursor).unwrap()
+    //     };
+    // }
 
-        leader_quotient_y_coeffs = {
-            let mut nom = degree2_evals_at_delta_x.clone();
-            polynomial_add(&mut nom, -E::Fr::ONE, &lagrange_degree2_delta_y);
-            univariate_roots_quotient(nom, &[beta_y, -beta_y, beta_y * beta_y])
-        };
+    // //
+    // // Local party compute the linear combined folded coeffs at x with gamma,
+    // // then the degree2 Lagrange over beta_x, -beta_x, beta_x^2,
+    // // then vanish the local aggregated x coeffs at the three points above,
+    // // and commit to the final quotient poly
+    // //
 
-        leader_quotient_y_commitment =
-            coeff_form_uni_kzg_commit(&srs.tau_y_srs, &leader_quotient_y_coeffs);
+    // let mut local_gamma_aggregated_x_coeffs = {
+    //     let mut f_gamma_local = coeff_form_hyperkzg_local_oracle_polys_aggregate::<E>(
+    //         coeffs.hypercube_basis_ref(),
+    //         &local_folded_x_oracle_coeffs,
+    //         gamma,
+    //     );
 
-        fs_transcript.append_u8_slice(leader_quotient_y_commitment.to_bytes().as_ref());
-    }
+    //     f_gamma_local[0] += leader_gamma_aggregated_y_coeffs[mpi_engine.world_rank()];
+    //     f_gamma_local
+    // };
 
-    transcript_root_broadcast(fs_transcript, mpi_engine);
+    // let local_lagrange_degree2_at_x = {
+    //     let mut local_degree_2 =
+    //         local_folded_x_evals.interpolate_degree2_aggregated_evals(beta_x, gamma);
 
-    let delta_y = fs_transcript.generate_field_element::<E::Fr>();
+    //     local_degree_2[0] += leader_gamma_aggregated_y_coeffs[mpi_engine.world_rank()];
+    //     local_degree_2
+    // };
 
-    //
-    // Leader send out the quotient on y coefficients back to local parties
-    //
+    // let local_gamma_aggregated_x_quotient = {
+    //     let mut nom = local_gamma_aggregated_x_coeffs.clone();
+    //     polynomial_add(&mut nom, -E::Fr::ONE, &local_lagrange_degree2_at_x);
+    //     univariate_roots_quotient(nom, &[beta_x, -beta_x, beta_x * beta_x])
+    // };
 
-    // TODO(HS) can be better if the root only send corresponding coeffs to the parties
-    {
-        let mut serialized_y_quotient_coeffs: Vec<u8> = Vec::new();
-        leader_quotient_y_coeffs
-            .serialize_into(&mut serialized_y_quotient_coeffs)
-            .unwrap();
+    // let local_gamma_aggregated_x_quotient_commitment_g1: E::G1 =
+    //     coeff_form_uni_kzg_commit(&srs.tau_x_srs, &local_gamma_aggregated_x_quotient).to_curve();
 
-        mpi_engine.root_broadcast_bytes(&mut serialized_y_quotient_coeffs);
-        leader_quotient_y_coeffs = {
-            let mut cursor = Cursor::new(serialized_y_quotient_coeffs);
-            Vec::deserialize_from(&mut cursor).unwrap()
-        };
-        leader_quotient_y_coeffs.resize(mpi_engine.world_size(), E::Fr::ZERO);
-    }
+    // //
+    // // Leader collect all the quotient commitment at x, sum it up and feed it to RO,
+    // // then sync transcript state
+    // //
 
-    //
-    // Final step for local - trip off the prior quotients at x and y on \pm beta and beta^2
-    //
+    // let mut root_gathering_gamma_aggregated_x_quotient_commitment_g1s: Vec<E::G1> =
+    //     vec![E::G1::generator(); mpi_engine.world_size()];
+    // mpi_engine.gather_vec(
+    //     &[local_gamma_aggregated_x_quotient_commitment_g1],
+    //     &mut root_gathering_gamma_aggregated_x_quotient_commitment_g1s,
+    // );
 
-    // NOTE(HS) f_gamma_s - (delta_x - beta_x) ... (delta_x - beta_x2) f_gamma_quotient_s
-    //                    - (delta_y - beta_y) ... (delta_y - beta_y2) lagrange_quotient_y
-    let delta_x_denom = (delta_x - beta_x) * (delta_x - beta_x * beta_x) * (delta_x + beta_x);
-    let delta_y_denom = (delta_y - beta_y) * (delta_y - beta_y * beta_y) * (delta_y + beta_y);
+    // let mut gamma_aggregated_x_quotient_commitment: E::G1Affine = E::G1Affine::default();
 
-    polynomial_add(
-        &mut local_gamma_aggregated_x_coeffs,
-        -delta_x_denom,
-        &local_gamma_aggregated_x_quotient,
-    );
-    local_gamma_aggregated_x_coeffs[0] -=
-        delta_y_denom * leader_quotient_y_coeffs[mpi_engine.world_rank()];
+    // if mpi_engine.is_root() {
+    //     gamma_aggregated_x_quotient_commitment =
+    //         root_gathering_gamma_aggregated_x_quotient_commitment_g1s
+    //             .iter()
+    //             .sum::<E::G1>()
+    //             .to_affine();
 
-    //
-    // BiKZG commit to the last bivariate poly
-    //
+    //     fs_transcript.append_u8_slice(gamma_aggregated_x_quotient_commitment.to_bytes().
+    // as_ref()); }
 
-    let mut gathered_eval_opens: Vec<(E::Fr, E::G1Affine)> =
-        vec![(E::Fr::ZERO, E::G1Affine::default()); mpi_engine.world_size()];
-    let local_eval_open =
-        coeff_form_uni_kzg_open_eval(&srs.tau_x_srs, &local_gamma_aggregated_x_coeffs, delta_x);
+    // transcript_root_broadcast(fs_transcript, mpi_engine);
 
-    mpi_engine.gather_vec(&[local_eval_open], &mut gathered_eval_opens);
+    // let delta_x = fs_transcript.generate_field_element::<E::Fr>();
 
-    if !mpi_engine.is_root() {
-        return None;
-    }
+    // //
+    // // Locally compute the Lagrange-degree2 interpolation at delta_x, pool at leader
+    // //
 
-    let (_, final_opening) = coeff_form_bi_kzg_open_leader(srs, &gathered_eval_opens, delta_y);
+    // let mut degree2_evals_at_delta_x: Vec<E::Fr> = vec![E::Fr::ZERO; mpi_engine.world_size()];
 
-    HyperBiKZGOpening {
-        folded_oracle_commitments,
-        aggregated_evals: root_aggregated_x_evals,
-        leader_evals: root_folded_y_evals.into(),
-        beta_x_commitment: gamma_aggregated_x_quotient_commitment,
-        beta_y_commitment: leader_quotient_y_commitment,
-        quotient_delta_x_commitment: final_opening.quotient_x,
-        quotient_delta_y_commitment: final_opening.quotient_y,
-    }
-    .into()
+    // let local_degree2_eval_at_delta_x = local_lagrange_degree2_at_x[0]
+    //     + local_lagrange_degree2_at_x[1] * delta_x
+    //     + local_lagrange_degree2_at_x[2] * delta_x * delta_x;
+
+    // mpi_engine.gather_vec(
+    //     &[local_degree2_eval_at_delta_x],
+    //     &mut degree2_evals_at_delta_x,
+    // );
+
+    // //
+    // // Leader does similar thing - quotient at beta_y, -beta_y, beta_y^2,
+    // // commit the quotient polynomial commitment at y, feed it to RO,
+    // // then sync transcript state
+    // //
+
+    // let mut leader_quotient_y_coeffs: Vec<E::Fr> = vec![E::Fr::ZERO; mpi_engine.world_size()];
+    // let mut leader_quotient_y_commitment: E::G1Affine = E::G1Affine::default();
+
+    // if mpi_engine.is_root() {
+    //     let num_y_coeffs = mpi_engine.world_size();
+
+    //     // NOTE(HS) interpolate at beta_y, beta_y2, -beta_y on lagrange_degree2_delta_x
+    //     let lagrange_degree2_delta_y = {
+    //         let pos_beta_y_pow_series = powers_series(&beta_y, num_y_coeffs);
+    //         let neg_beta_y_pow_series = powers_series(&(-beta_y), num_y_coeffs);
+    //         let beta_y2_pow_series = powers_series(&(beta_y * beta_y), num_y_coeffs);
+
+    //         let at_beta_y = univariate_evaluate(&degree2_evals_at_delta_x,
+    // &pos_beta_y_pow_series);         let at_neg_beta_y =
+    //             univariate_evaluate(&degree2_evals_at_delta_x, &neg_beta_y_pow_series);
+    //         let at_beta_y2 = univariate_evaluate(&degree2_evals_at_delta_x, &beta_y2_pow_series);
+
+    //         coeff_form_degree2_lagrange(
+    //             [beta_y, -beta_y, beta_y * beta_y],
+    //             [at_beta_y, at_neg_beta_y, at_beta_y2],
+    //         )
+    //     };
+
+    //     leader_quotient_y_coeffs = {
+    //         let mut nom = degree2_evals_at_delta_x.clone();
+    //         polynomial_add(&mut nom, -E::Fr::ONE, &lagrange_degree2_delta_y);
+    //         univariate_roots_quotient(nom, &[beta_y, -beta_y, beta_y * beta_y])
+    //     };
+
+    //     leader_quotient_y_commitment =
+    //         coeff_form_uni_kzg_commit(&srs.tau_y_srs, &leader_quotient_y_coeffs);
+
+    //     fs_transcript.append_u8_slice(leader_quotient_y_commitment.to_bytes().as_ref());
+    // }
+
+    // transcript_root_broadcast(fs_transcript, mpi_engine);
+
+    // let delta_y = fs_transcript.generate_field_element::<E::Fr>();
+
+    // //
+    // // Leader send out the quotient on y coefficients back to local parties
+    // //
+
+    // // TODO(HS) can be better if the root only send corresponding coeffs to the parties
+    // {
+    //     let mut serialized_y_quotient_coeffs: Vec<u8> = Vec::new();
+    //     leader_quotient_y_coeffs
+    //         .serialize_into(&mut serialized_y_quotient_coeffs)
+    //         .unwrap();
+
+    //     mpi_engine.root_broadcast_bytes(&mut serialized_y_quotient_coeffs);
+    //     leader_quotient_y_coeffs = {
+    //         let mut cursor = Cursor::new(serialized_y_quotient_coeffs);
+    //         Vec::deserialize_from(&mut cursor).unwrap()
+    //     };
+    //     leader_quotient_y_coeffs.resize(mpi_engine.world_size(), E::Fr::ZERO);
+    // }
+
+    // //
+    // // Final step for local - trip off the prior quotients at x and y on \pm beta and beta^2
+    // //
+
+    // // NOTE(HS) f_gamma_s - (delta_x - beta_x) ... (delta_x - beta_x2) f_gamma_quotient_s
+    // //                    - (delta_y - beta_y) ... (delta_y - beta_y2) lagrange_quotient_y
+    // let delta_x_denom = (delta_x - beta_x) * (delta_x - beta_x * beta_x) * (delta_x + beta_x);
+    // let delta_y_denom = (delta_y - beta_y) * (delta_y - beta_y * beta_y) * (delta_y + beta_y);
+
+    // polynomial_add(
+    //     &mut local_gamma_aggregated_x_coeffs,
+    //     -delta_x_denom,
+    //     &local_gamma_aggregated_x_quotient,
+    // );
+    // local_gamma_aggregated_x_coeffs[0] -=
+    //     delta_y_denom * leader_quotient_y_coeffs[mpi_engine.world_rank()];
+
+    // //
+    // // BiKZG commit to the last bivariate poly
+    // //
+
+    // let mut gathered_eval_opens: Vec<(E::Fr, E::G1Affine)> =
+    //     vec![(E::Fr::ZERO, E::G1Affine::default()); mpi_engine.world_size()];
+    // let local_eval_open =
+    //     coeff_form_uni_kzg_open_eval(&srs.tau_x_srs, &local_gamma_aggregated_x_coeffs, delta_x);
+
+    // mpi_engine.gather_vec(&[local_eval_open], &mut gathered_eval_opens);
+
+    // if !mpi_engine.is_root() {
+    //     return None;
+    // }
+
+    // let (_, final_opening) = coeff_form_bi_kzg_open_leader(srs, &gathered_eval_opens, delta_y);
+
+    // HyperBiKZGOpening {
+    //     folded_oracle_commitments,
+    //     aggregated_evals: root_aggregated_x_evals,
+    //     leader_evals: root_folded_y_evals.into(),
+    //     beta_x_commitment: gamma_aggregated_x_quotient_commitment,
+    //     beta_y_commitment: leader_quotient_y_commitment,
+    //     quotient_delta_x_commitment: final_opening.quotient_x,
+    //     quotient_delta_y_commitment: final_opening.quotient_y,
+    // }
+    // .into()
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/poly_commit/src/kzg/univariate.rs
+++ b/poly_commit/src/kzg/univariate.rs
@@ -56,10 +56,10 @@ where
     assert!(srs.powers_of_tau.len() >= coeffs.len());
 
     let mut com = E::G1::generator() * E::Fr::ZERO;
-    // let timer = ::utils::timer::Timer::new(format!("kzg commit msm {}", coeffs.len()).as_ref(),
-    // true);
+    let timer =
+        ::utils::timer::Timer::new(format!("kzg commit msm {}", coeffs.len()).as_ref(), true);
     msm::multiexp_serial(coeffs, &srs.powers_of_tau[..coeffs.len()], &mut com);
-    // timer.stop();
+    timer.stop();
 
     com.into()
 }

--- a/poly_commit/src/kzg/univariate.rs
+++ b/poly_commit/src/kzg/univariate.rs
@@ -55,10 +55,10 @@ where
 {
     assert!(srs.powers_of_tau.len() >= coeffs.len());
 
-    let mut com = E::G1::generator() * E::Fr::ZERO;
+    // let mut com = E::G1::generator() * E::Fr::ZERO;
     let timer =
         ::utils::timer::Timer::new(format!("kzg commit msm {}", coeffs.len()).as_ref(), true);
-    msm::multiexp_serial(coeffs, &srs.powers_of_tau[..coeffs.len()], &mut com);
+    let com = msm::best_multiexp(coeffs, &srs.powers_of_tau[..coeffs.len()]); //&mut com);
     timer.stop();
 
     com.into()
@@ -77,11 +77,11 @@ where
     assert!(srs.powers_of_tau.len() >= coeffs.len());
 
     let (div, eval) = univariate_degree_one_quotient(coeffs, alpha);
-    let mut opening = E::G1::generator() * E::Fr::ZERO;
+    // let mut opening = E::G1::generator() * E::Fr::ZERO;
 
     // let timer = ::utils::timer::Timer::new(format!("kzg open msm {}", div.len()).as_ref(), true);
-    msm::multiexp_serial(&div, &srs.powers_of_tau[..div.len()], &mut opening);
-    // timer.stop();
+    let opening = msm::best_multiexp(&div, &srs.powers_of_tau[..div.len()]); //&mut opening);
+                                                                             // timer.stop();
 
     (eval, opening.into())
 }

--- a/poly_commit/src/raw.rs
+++ b/poly_commit/src/raw.rs
@@ -138,7 +138,7 @@ impl<C: FieldEngine> ExpanderPCS<C> for RawExpanderGKR<C> {
 
     fn gen_srs_for_testing(
         params: &Self::Params,
-        _mpi_engine: &impl MPIEngine,
+        // _mpi_engine: &impl MPIEngine,
         _rng: impl RngCore,
     ) -> (Self::SRS, usize) {
         ((), *params)
@@ -152,38 +152,38 @@ impl<C: FieldEngine> ExpanderPCS<C> for RawExpanderGKR<C> {
 
     fn commit(
         params: &Self::Params,
-        mpi_engine: &impl MPIEngine,
+        // mpi_engine: &impl MPIEngine,
         _proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
         poly: &impl MultilinearExtension<C::SimdCircuitField>,
         _scratch_pad: &mut Self::ScratchPad,
     ) -> Option<Self::Commitment> {
         assert!(poly.num_vars() == *params);
 
-        if mpi_engine.is_single_process() {
-            return Self::Commitment {
-                evals: poly.hypercube_basis(),
-            }
-            .into();
+        // if mpi_engine.is_single_process() {
+        return Self::Commitment {
+            evals: poly.hypercube_basis(),
         }
+        .into();
+        // }
 
-        let mut buffer = if mpi_engine.is_root() {
-            vec![C::SimdCircuitField::zero(); poly.hypercube_size() * mpi_engine.world_size()]
-        } else {
-            vec![]
-        };
+        // let mut buffer = if mpi_engine.is_root() {
+        //     vec![C::SimdCircuitField::zero(); poly.hypercube_size() * mpi_engine.world_size()]
+        // } else {
+        //     vec![]
+        // };
 
-        mpi_engine.gather_vec(poly.hypercube_basis_ref(), &mut buffer);
+        // mpi_engine.gather_vec(poly.hypercube_basis_ref(), &mut buffer);
 
-        if !mpi_engine.is_root() {
-            return None;
-        }
+        // if !mpi_engine.is_root() {
+        //     return None;
+        // }
 
-        Self::Commitment { evals: buffer }.into()
+        // Self::Commitment { evals: buffer }.into()
     }
 
     fn open(
         _params: &Self::Params,
-        _mpi_engine: &impl MPIEngine,
+        // _mpi_engine: &impl MPIEngine,
         _proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
         _poly: &impl MultilinearExtension<C::SimdCircuitField>,
         _x: &ExpanderSingleVarChallenge<C>,

--- a/poly_commit/src/utils.rs
+++ b/poly_commit/src/utils.rs
@@ -16,7 +16,11 @@ pub fn expander_pcs_init_testing_only<FieldConfig: FieldEngine, PCS: ExpanderPCS
 
     let mut pcs_params = <PCS as ExpanderPCS<FieldConfig>>::gen_params(n_input_vars);
     let (pcs_setup, calibrated_num_local_simd_vars) =
-        <PCS as ExpanderPCS<FieldConfig>>::gen_srs_for_testing(&pcs_params, mpi_config, &mut rng);
+        <PCS as ExpanderPCS<FieldConfig>>::gen_srs_for_testing(
+            &pcs_params,
+            // mpi_config,
+            &mut rng,
+        );
 
     if n_input_vars < calibrated_num_local_simd_vars {
         eprintln!(

--- a/poly_commit/tests/common.rs
+++ b/poly_commit/tests/common.rs
@@ -53,11 +53,19 @@ pub fn test_pcs_for_expander_gkr<C: FieldEngine, T: Transcript, P: ExpanderPCS<C
 ) {
     let mut rng = test_rng();
     // NOTE(HS) we assume that the polynomials we pass in are of sufficient length.
-    let (srs, _) = P::gen_srs_for_testing(params, mpi_config, &mut rng);
+    let (srs, _) = P::gen_srs_for_testing(
+        params, //mpi_config,
+        &mut rng,
+    );
     let (proving_key, verification_key) = srs.into_keys();
     let mut scratch_pad = P::init_scratch_pad(params, mpi_config);
 
-    let commitment = P::commit(params, mpi_config, &proving_key, poly, &mut scratch_pad);
+    let commitment = P::commit(
+        params, //mpi_config,
+        &proving_key,
+        poly,
+        &mut scratch_pad,
+    );
 
     // PCSForExpanderGKR does not require an evaluation value for the opening function
     // We use RawExpanderGKR as the golden standard for the evaluation value
@@ -75,7 +83,7 @@ pub fn test_pcs_for_expander_gkr<C: FieldEngine, T: Transcript, P: ExpanderPCS<C
         transcript.lock_proof();
         let opening = P::open(
             params,
-            mpi_config,
+            // mpi_config,
             &proving_key,
             poly,
             xx,


### PR DESCRIPTION
# design rational

MPI is used for GKR for sync up transcripts. Intuitively, for (most) PCS there is no message passing between threads, and therefore  it does not make sense to use MPI to compute PCS.

Practically, it seems that some of the KZG openings are single threaded and is only invoked when `mpi_config.is_root()`. When this happens, the rest of the cores seem to be idle.

# outcome 

This PR is to remove MPI from PCS, and rely on rayon for multi-threading. 
Local tests shows that for keccak circuit with Hyrax and thread = 16, the e2e proving speed is increased from 80 keccak per second to 93 keccak per second.

**pending zkpytorch E2E test to confirm performance improvement.** This PR still requires a lot of clean ups.