### PR TITLE
[feat] use uncompressed form for hyrax commitment

### DIFF
--- a/poly_commit/src/hyrax/expander_api.rs
+++ b/poly_commit/src/hyrax/expander_api.rs
@@ -3,9 +3,7 @@ use gkr_engine::{
     ExpanderPCS, ExpanderSingleVarChallenge, FieldEngine, MPIEngine, PolynomialCommitmentType,
     StructuredReferenceString, Transcript,
 };
-use halo2curves::{
-    bn256::G1Uncompressed, ff::PrimeField, group::UncompressedEncoding, msm, CurveAffine,
-};
+use halo2curves::{ff::PrimeField, group::UncompressedEncoding, msm, CurveAffine};
 use polynomials::{
     EqPolynomial, MultilinearExtension, MutRefMultiLinearPoly, MutableMultilinearExtension,
     RefMultiLinearPoly,
@@ -23,7 +21,7 @@ use crate::{
 impl<G, C> ExpanderPCS<G, C::Scalar> for HyraxPCS<C>
 where
     G: FieldEngine<ChallengeField = C::Scalar, SimdCircuitField = C::Scalar>,
-    C: CurveAffine + ExpSerde + UncompressedEncoding<Uncompressed = G1Uncompressed>,
+    C: CurveAffine + ExpSerde + UncompressedEncoding,
     C::Scalar: ExtensionField + PrimeField,
     C::ScalarExt: ExtensionField + PrimeField,
     C::Base: PrimeField<Repr = [u8; 32]>,

--- a/poly_commit/src/hyrax/expander_api.rs
+++ b/poly_commit/src/hyrax/expander_api.rs
@@ -3,7 +3,9 @@ use gkr_engine::{
     ExpanderPCS, ExpanderSingleVarChallenge, FieldEngine, MPIEngine, PolynomialCommitmentType,
     StructuredReferenceString, Transcript,
 };
-use halo2curves::{ff::PrimeField, msm, CurveAffine};
+use halo2curves::{
+    bn256::G1Uncompressed, ff::PrimeField, group::UncompressedEncoding, msm, CurveAffine,
+};
 use polynomials::{
     EqPolynomial, MultilinearExtension, MutRefMultiLinearPoly, MutableMultilinearExtension,
     RefMultiLinearPoly,
@@ -21,7 +23,7 @@ use crate::{
 impl<G, C> ExpanderPCS<G, C::Scalar> for HyraxPCS<C>
 where
     G: FieldEngine<ChallengeField = C::Scalar, SimdCircuitField = C::Scalar>,
-    C: CurveAffine + ExpSerde,
+    C: CurveAffine + ExpSerde + UncompressedEncoding<Uncompressed = G1Uncompressed>,
     C::Scalar: ExtensionField + PrimeField,
     C::ScalarExt: ExtensionField + PrimeField,
     C::Base: PrimeField<Repr = [u8; 32]>,

--- a/poly_commit/src/hyrax/hyrax_impl.rs
+++ b/poly_commit/src/hyrax/hyrax_impl.rs
@@ -39,7 +39,7 @@ where
 #[derive(Clone, Debug, Default)]
 pub struct HyraxCommitment<C>(pub Vec<C>)
 where
-    C: CurveAffine + ExpSerde;
+    C: CurveAffine + ExpSerde + UncompressedEncoding;
 
 #[derive(Clone, Debug, Default)]
 pub struct HyraxOpening<C>(pub Vec<C::Scalar>)

--- a/poly_commit/src/hyrax/hyrax_impl.rs
+++ b/poly_commit/src/hyrax/hyrax_impl.rs
@@ -1,7 +1,5 @@
 use arith::ExtensionField;
-use halo2curves::{
-    bn256::G1Uncompressed, ff::PrimeField, group::UncompressedEncoding, msm, CurveAffine,
-};
+use halo2curves::{ff::PrimeField, group::UncompressedEncoding, msm, CurveAffine};
 use polynomials::{
     EqPolynomial, MultilinearExtension, MutRefMultiLinearPoly, MutableMultilinearExtension,
     RefMultiLinearPoly,
@@ -46,11 +44,11 @@ where
 #[derive(Clone, Debug, Default)]
 pub struct HyraxOpening<C>(pub Vec<C::Scalar>)
 where
-    C: CurveAffine + ExpSerde + UncompressedEncoding<Uncompressed = G1Uncompressed>;
+    C: CurveAffine + ExpSerde + UncompressedEncoding;
 
 impl<C> ExpSerde for HyraxCommitment<C>
 where
-    C: CurveAffine + ExpSerde + UncompressedEncoding<Uncompressed = G1Uncompressed>,
+    C: CurveAffine + ExpSerde + UncompressedEncoding,
 {
     fn serialize_into<W: std::io::Write>(&self, mut writer: W) -> serdes::SerdeResult<()> {
         self.0.len().serialize_into(&mut writer)?;
@@ -65,7 +63,7 @@ where
         let num_elements = usize::deserialize_from(&mut reader)?;
 
         let mut buffer = [0u8; 64];
-        let mut uncompressed = G1Uncompressed::default();
+        let mut uncompressed = <C as UncompressedEncoding>::Uncompressed::default();
 
         let mut elements = Vec::with_capacity(num_elements);
         for _ in 0..num_elements {
@@ -79,7 +77,7 @@ where
 
 impl<C> ExpSerde for HyraxOpening<C>
 where
-    C: CurveAffine + ExpSerde + UncompressedEncoding<Uncompressed = G1Uncompressed>,
+    C: CurveAffine + ExpSerde + UncompressedEncoding,
     C::Scalar: ExpSerde,
 {
     fn serialize_into<W: std::io::Write>(&self, writer: W) -> serdes::SerdeResult<()> {
@@ -97,7 +95,7 @@ pub(crate) fn hyrax_commit<C>(
     mle_poly: &impl MultilinearExtension<C::Scalar>,
 ) -> HyraxCommitment<C>
 where
-    C: CurveAffine + ExpSerde + UncompressedEncoding<Uncompressed = G1Uncompressed>,
+    C: CurveAffine + ExpSerde + UncompressedEncoding,
     C::Scalar: ExtensionField + PrimeField,
     C::ScalarExt: ExtensionField + PrimeField,
     C::Base: PrimeField<Repr = [u8; 32]>,
@@ -118,7 +116,7 @@ pub(crate) fn hyrax_open<C>(
     eval_point: &[C::Scalar],
 ) -> (C::Scalar, HyraxOpening<C>)
 where
-    C: CurveAffine + ExpSerde + UncompressedEncoding<Uncompressed = G1Uncompressed>,
+    C: CurveAffine + ExpSerde + UncompressedEncoding,
     C::Scalar: ExtensionField + PrimeField,
     C::ScalarExt: ExtensionField + PrimeField,
     C::Base: PrimeField<Repr = [u8; 32]>,
@@ -144,7 +142,7 @@ pub(crate) fn hyrax_verify<C>(
     proof: &HyraxOpening<C>,
 ) -> bool
 where
-    C: CurveAffine + ExpSerde + UncompressedEncoding<Uncompressed = G1Uncompressed>,
+    C: CurveAffine + ExpSerde + UncompressedEncoding,
     C::Scalar: ExtensionField + PrimeField,
     C::ScalarExt: ExtensionField + PrimeField,
     C::Base: PrimeField<Repr = [u8; 32]>,

--- a/poly_commit/src/hyrax/pcs_trait_impl.rs
+++ b/poly_commit/src/hyrax/pcs_trait_impl.rs
@@ -2,7 +2,9 @@ use std::marker::PhantomData;
 
 use arith::ExtensionField;
 use gkr_engine::{StructuredReferenceString, Transcript};
-use halo2curves::{ff::PrimeField, CurveAffine};
+use halo2curves::{
+    bn256::G1Uncompressed, ff::PrimeField, group::UncompressedEncoding, CurveAffine,
+};
 use polynomials::MultiLinearPoly;
 use serdes::ExpSerde;
 
@@ -13,7 +15,7 @@ use crate::{
 
 pub struct HyraxPCS<C>
 where
-    C: CurveAffine,
+    C: CurveAffine + ExpSerde + UncompressedEncoding<Uncompressed = G1Uncompressed>,
     C::Scalar: ExtensionField,
     C::ScalarExt: ExtensionField,
 {
@@ -22,7 +24,7 @@ where
 
 impl<C> PolynomialCommitmentScheme<C::Scalar> for HyraxPCS<C>
 where
-    C: CurveAffine + ExpSerde,
+    C: CurveAffine + ExpSerde + UncompressedEncoding<Uncompressed = G1Uncompressed>,
     C::Scalar: ExtensionField + PrimeField,
     C::ScalarExt: ExtensionField + PrimeField,
     C::Base: PrimeField<Repr = [u8; 32]>,

--- a/poly_commit/src/hyrax/pcs_trait_impl.rs
+++ b/poly_commit/src/hyrax/pcs_trait_impl.rs
@@ -2,9 +2,7 @@ use std::marker::PhantomData;
 
 use arith::ExtensionField;
 use gkr_engine::{StructuredReferenceString, Transcript};
-use halo2curves::{
-    bn256::G1Uncompressed, ff::PrimeField, group::UncompressedEncoding, CurveAffine,
-};
+use halo2curves::{ff::PrimeField, group::UncompressedEncoding, CurveAffine};
 use polynomials::MultiLinearPoly;
 use serdes::ExpSerde;
 
@@ -15,7 +13,7 @@ use crate::{
 
 pub struct HyraxPCS<C>
 where
-    C: CurveAffine + ExpSerde + UncompressedEncoding<Uncompressed = G1Uncompressed>,
+    C: CurveAffine + ExpSerde + UncompressedEncoding,
     C::Scalar: ExtensionField,
     C::ScalarExt: ExtensionField,
 {
@@ -24,7 +22,7 @@ where
 
 impl<C> PolynomialCommitmentScheme<C::Scalar> for HyraxPCS<C>
 where
-    C: CurveAffine + ExpSerde + UncompressedEncoding<Uncompressed = G1Uncompressed>,
+    C: CurveAffine + ExpSerde + UncompressedEncoding,
     C::Scalar: ExtensionField + PrimeField,
     C::ScalarExt: ExtensionField + PrimeField,
     C::Base: PrimeField<Repr = [u8; 32]>,


### PR DESCRIPTION
currently hyrax uses compressed form for serialization. At the deserialization step, the verifier will need to uncompress the hyrax commitments. In some use case this may leads to millions of group elements.

in this PR, a hyrax commitment is deserialized in uncompressed mode so verifier does not need to pay for this cost.  