### PR TITLE
[fix] cargo doc

### DIFF
--- a/arith/gf2/src/gf2x64.rs
+++ b/arith/gf2/src/gf2x64.rs
@@ -25,8 +25,10 @@ impl Field for GF2x64 {
 
     const ONE: Self = GF2x64 { v: !0u64 };
 
+    #[doc(hidden)]
     const INV_2: Self = unimplemented!(); // NOTE: should not be used
 
+    #[doc(hidden)]
     const MODULUS: U256 = unimplemented!(); // should not be used
 
     #[inline(always)]

--- a/arith/gf2/src/gf2x8.rs
+++ b/arith/gf2/src/gf2x8.rs
@@ -27,6 +27,7 @@ impl Field for GF2x8 {
 
     const INV_2: Self = GF2x8 { v: 0 };
 
+    #[doc(hidden)]
     const MODULUS: U256 = unimplemented!(); // should not be used
 
     #[inline(always)]


### PR DESCRIPTION
`cargo doc` fails when evaluating these `unimplemented!`.