### PR TITLE
api change in pcs to allow pass by reference

### DIFF
--- a/gkr_engine/src/poly_commit/definition.rs
+++ b/gkr_engine/src/poly_commit/definition.rs
@@ -1,5 +1,5 @@
 use arith::Field;
-use polynomials::{MultiLinearPoly, MultilinearExtension};
+use polynomials::MultilinearExtension;
 use rand::RngCore;
 use serdes::ExpSerde;
 use std::{fmt::Debug, str::FromStr};
@@ -162,7 +162,7 @@ pub trait ExpanderPCS<F: FieldEngine, PolyField: Field> {
         _params: &Self::Params,
         _mpi_engine: &impl MPIEngine,
         _proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
-        _polys: &[MultiLinearPoly<PolyField>],
+        _polys: &[impl MultilinearExtension<PolyField>],
         _x: &[ExpanderSingleVarChallenge<F>],
         _scratch_pad: &Self::ScratchPad,
         _transcript: &mut impl Transcript,
@@ -174,7 +174,7 @@ pub trait ExpanderPCS<F: FieldEngine, PolyField: Field> {
     fn multi_points_batch_verify(
         _params: &Self::Params,
         _verifying_key: &<Self::SRS as StructuredReferenceString>::VKey,
-        _commitments: &[Self::Commitment],
+        _commitments: &[impl AsRef<Self::Commitment>],
         _x: &[ExpanderSingleVarChallenge<F>],
         _evals: &[F::ChallengeField],
         _opening: &Self::BatchOpening,

--- a/poly_commit/src/batching.rs
+++ b/poly_commit/src/batching.rs
@@ -20,8 +20,8 @@ use utils::timer::Timer;
 /// - the proof of the sumcheck
 #[allow(clippy::type_complexity)]
 pub fn prover_merge_points<C>(
-    polys: &[MultiLinearPoly<C::Scalar>],
-    points: &[Vec<C::Scalar>],
+    polys: &[impl MultilinearExtension<C::Scalar>],
+    points: &[impl AsRef<[C::Scalar]>],
     transcript: &mut impl Transcript,
 ) -> (
     Vec<C::Scalar>,
@@ -110,7 +110,7 @@ where
 
 pub fn verifier_merge_points<C>(
     commitments: &[impl AsRef<[C]>],
-    points: &[Vec<C::Scalar>],
+    points: &[impl AsRef<[C::Scalar]>],
     values: &[C::Scalar],
     sumcheck_proof: &IOPProof<C::Scalar>,
     transcript: &mut impl Transcript,
@@ -198,8 +198,8 @@ fn transpose<C: CurveAffine>(m: &[&[C]]) -> Vec<Vec<C>> {
 #[inline]
 #[allow(clippy::type_complexity)]
 fn pad_polynomials_and_points<C>(
-    polys: &[MultiLinearPoly<C::Scalar>],
-    points: &[Vec<C::Scalar>],
+    polys: &[impl MultilinearExtension<C::Scalar>],
+    points: &[impl AsRef<[C::Scalar]>],
 ) -> (Vec<MultiLinearPoly<C::Scalar>>, Vec<Vec<C::Scalar>>)
 where
     C: CurveAffine + ExpSerde,
@@ -215,7 +215,7 @@ where
     let padded_polys = polys
         .iter()
         .map(|poly| {
-            let mut coeffs = poly.coeffs.clone();
+            let mut coeffs = poly.hypercube_basis_ref().to_vec();
             coeffs.resize(max_size, C::Scalar::zero());
             MultiLinearPoly { coeffs }
         })
@@ -223,7 +223,7 @@ where
     let padded_points = points
         .iter()
         .map(|point| {
-            let mut padded_point = point.clone();
+            let mut padded_point = point.as_ref().to_vec();
             padded_point.resize(max_num_vars, C::Scalar::zero());
             padded_point
         })
@@ -237,14 +237,14 @@ where
 // This generalizes both KZG and Hyrax commitments
 fn pad_commitments_and_points<C>(
     commitments: &[impl AsRef<[C]>],
-    points: &[Vec<C::Scalar>],
+    points: &[impl AsRef<[C::Scalar]>],
 ) -> (Vec<Vec<C>>, Vec<Vec<C::Scalar>>)
 where
     C: CurveAffine + ExpSerde,
     C::Scalar: ExtensionField + PrimeField,
     C::ScalarExt: ExtensionField + PrimeField,
 {
-    let max_num_vars = points.iter().map(|p| p.len()).max().unwrap_or(0);
+    let max_num_vars = points.iter().map(|p| p.as_ref().len()).max().unwrap_or(0);
     let max_commit_size = commitments
         .iter()
         .map(|c| c.as_ref().len())
@@ -254,7 +254,7 @@ where
     let padded_points = points
         .iter()
         .map(|point| {
-            let mut padded_point = point.clone();
+            let mut padded_point = point.as_ref().to_vec();
             padded_point.resize(max_num_vars, C::Scalar::zero());
             padded_point
         })

--- a/poly_commit/src/hyrax/expander_api.rs
+++ b/poly_commit/src/hyrax/expander_api.rs
@@ -5,8 +5,8 @@ use gkr_engine::{
 };
 use halo2curves::{ff::PrimeField, group::UncompressedEncoding, msm, CurveAffine};
 use polynomials::{
-    EqPolynomial, MultiLinearPoly, MultilinearExtension, MutRefMultiLinearPoly,
-    MutableMultilinearExtension, RefMultiLinearPoly,
+    EqPolynomial, MultilinearExtension, MutRefMultiLinearPoly, MutableMultilinearExtension,
+    RefMultiLinearPoly,
 };
 use serdes::ExpSerde;
 
@@ -157,7 +157,7 @@ where
         _params: &Self::Params,
         mpi_engine: &impl MPIEngine,
         proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
-        mle_poly_list: &[MultiLinearPoly<C::Scalar>],
+        mle_poly_list: &[impl MultilinearExtension<C::Scalar>],
         eval_points: &[ExpanderSingleVarChallenge<G>],
         _scratch_pad: &Self::ScratchPad,
         transcript: &mut impl Transcript,
@@ -176,7 +176,7 @@ where
     fn multi_points_batch_verify(
         _params: &Self::Params,
         verifying_key: &<Self::SRS as StructuredReferenceString>::VKey,
-        commitments: &[Self::Commitment],
+        commitments: &[impl AsRef<Self::Commitment>],
         x: &[ExpanderSingleVarChallenge<G>],
         evals: &[<G as FieldEngine>::ChallengeField],
         batch_opening: &Self::BatchOpening,

--- a/poly_commit/src/hyrax/hyrax_impl.rs
+++ b/poly_commit/src/hyrax/hyrax_impl.rs
@@ -1,7 +1,6 @@
 use arith::{ExtensionField, Field};
 use gkr_engine::Transcript;
 use halo2curves::{ff::PrimeField, group::UncompressedEncoding, msm, CurveAffine};
-use polynomials::MultiLinearPoly;
 use polynomials::{
     EqPolynomial, MultilinearExtension, MutRefMultiLinearPoly, MutableMultilinearExtension,
     RefMultiLinearPoly,

--- a/poly_commit/src/hyrax/hyrax_impl.rs
+++ b/poly_commit/src/hyrax/hyrax_impl.rs
@@ -52,6 +52,19 @@ pub struct HyraxCommitment<C>(pub Vec<C>)
 where
     C: CurveAffine + ExpSerde + UncompressedEncoding;
 
+/// Jutification: from AsRef Documentation:
+///  Ideally, `AsRef` would be reflexive, i.e. there would be an `impl<T: ?Sized> AsRef<T> for T`
+///  Such a blanket implementation is currently *not* provided due to technical restrictions of
+///  Rust's type system
+impl<C> AsRef<HyraxCommitment<C>> for HyraxCommitment<C>
+where
+    C: CurveAffine + ExpSerde + UncompressedEncoding,
+{
+    fn as_ref(&self) -> &HyraxCommitment<C> {
+        self
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct HyraxOpening<C>(pub Vec<C::Scalar>)
 where
@@ -325,7 +338,7 @@ fn scale<F: Field>(base: &[F], scalar: &F) -> Vec<F> {
 #[allow(clippy::type_complexity)]
 pub(crate) fn hyrax_multi_points_batch_open_internal<C>(
     proving_key: &PedersenParams<C>,
-    polys: &[MultiLinearPoly<C::Scalar>],
+    polys: &[impl MultilinearExtension<C::Scalar>],
     points: &[Vec<C::Scalar>],
     transcript: &mut impl Transcript,
 ) -> (Vec<C::Scalar>, BatchOpening<C::Scalar, HyraxPCS<C>>)
@@ -341,7 +354,7 @@ where
     let evals: Vec<C::Scalar> = polys
         .par_iter()
         .zip_eq(points.par_iter())
-        .map(|(poly, point)| poly.evaluate_jolt(point))
+        .map(|(poly, point)| poly.evaluate(point))
         .collect();
     eval_timer.stop();
 
@@ -374,7 +387,7 @@ where
 /// 4. verify commitment
 pub(crate) fn hyrax_multi_points_batch_verify_internal<C>(
     verifying_key: &PedersenParams<C>,
-    commitments: &[HyraxCommitment<C>],
+    commitments: &[impl AsRef<HyraxCommitment<C>>],
     points: &[Vec<C::Scalar>],
     values: &[C::Scalar],
     batch_opening: &BatchOpening<C::Scalar, HyraxPCS<C>>,
@@ -388,7 +401,10 @@ where
 {
     let a2 = batch_opening.sum_check_proof.export_point_to_expander();
 
-    let commitments = commitments.iter().map(|c| c.0.clone()).collect::<Vec<_>>();
+    let commitments = commitments
+        .iter()
+        .map(|c| c.as_ref().0.clone())
+        .collect::<Vec<_>>();
 
     let (tilde_g_eval, g_prime_commit) = verifier_merge_points(
         &commitments,

--- a/poly_commit/src/kzg/uni_kzg/expander_api.rs
+++ b/poly_commit/src/kzg/uni_kzg/expander_api.rs
@@ -101,27 +101,20 @@ where
         params: &Self::Params,
         _mpi_engine: &impl MPIEngine,
         proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
-        polys: &[MultiLinearPoly<E::Fr>],
+        polys: &[impl MultilinearExtension<E::Fr>],
         x: &[ExpanderSingleVarChallenge<G>],
         scratch_pad: &Self::ScratchPad,
         transcript: &mut impl Transcript,
     ) -> (Vec<E::Fr>, Self::BatchOpening) {
         let points: Vec<Vec<E::Fr>> = x.iter().map(|p| p.local_xs()).collect();
 
-        <Self as BatchOpeningPCS<E::Fr>>::multiple_points_batch_open(
-            params,
-            proving_key,
-            polys,
-            points.as_ref(),
-            scratch_pad,
-            transcript,
-        )
+        multiple_points_batch_open_impl(proving_key, polys, points.as_ref(), transcript)
     }
 
     fn multi_points_batch_verify(
-        params: &Self::Params,
+        _params: &Self::Params,
         verifying_key: &<Self::SRS as StructuredReferenceString>::VKey,
-        commitments: &[Self::Commitment],
+        commitments: &[impl AsRef<Self::Commitment>],
         x: &[ExpanderSingleVarChallenge<G>],
         evals: &[E::Fr],
         batch_opening: &Self::BatchOpening,
@@ -129,8 +122,7 @@ where
     ) -> bool {
         let points: Vec<Vec<E::Fr>> = x.iter().map(|p| p.local_xs()).collect();
 
-        <Self as BatchOpeningPCS<E::Fr>>::multiple_points_batch_verify(
-            params,
+        multiple_points_batch_verify_impl(
             verifying_key,
             commitments,
             points.as_ref(),

--- a/poly_commit/src/kzg/uni_kzg/expander_api.rs
+++ b/poly_commit/src/kzg/uni_kzg/expander_api.rs
@@ -8,7 +8,7 @@ use halo2curves::{
     pairing::{Engine, MultiMillerLoop},
     CurveAffine,
 };
-use polynomials::{MultiLinearPoly, MultilinearExtension};
+use polynomials::MultilinearExtension;
 use serdes::ExpSerde;
 
 use crate::{traits::BatchOpening, *};
@@ -98,12 +98,12 @@ where
 
     /// Open a set of polynomials at a point.
     fn multi_points_batch_open(
-        params: &Self::Params,
+        _params: &Self::Params,
         _mpi_engine: &impl MPIEngine,
         proving_key: &<Self::SRS as StructuredReferenceString>::PKey,
         polys: &[impl MultilinearExtension<E::Fr>],
         x: &[ExpanderSingleVarChallenge<G>],
-        scratch_pad: &Self::ScratchPad,
+        _scratch_pad: &Self::ScratchPad,
         transcript: &mut impl Transcript,
     ) -> (Vec<E::Fr>, Self::BatchOpening) {
         let points: Vec<Vec<E::Fr>> = x.iter().map(|p| p.local_xs()).collect();

--- a/poly_commit/src/kzg/uni_kzg/hyper_kzg.rs
+++ b/poly_commit/src/kzg/uni_kzg/hyper_kzg.rs
@@ -1,17 +1,24 @@
 use std::iter;
 
+use ::utils::timer::Timer;
 use arith::ExtensionField;
 use gkr_engine::Transcript;
 use halo2curves::{
-    ff::Field,
+    ff::{Field, PrimeField},
     group::{prime::PrimeCurveAffine, GroupEncoding},
-    pairing::MultiMillerLoop,
+    pairing::{Engine, MultiMillerLoop},
     CurveAffine,
 };
 use itertools::izip;
+use polynomials::MultilinearExtension;
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use serdes::ExpSerde;
 
-use crate::*;
+use crate::{
+    batching::{prover_merge_points, verifier_merge_points},
+    traits::BatchOpening,
+    *,
+};
 
 #[inline(always)]
 pub(crate) fn coeff_form_hyperkzg_local_poly_oracles<E>(
@@ -236,4 +243,89 @@ where
     );
 
     true
+}
+
+pub fn multiple_points_batch_open_impl<E, PCS>(
+    proving_key: &CoefFormUniKZGSRS<E>,
+    polys: &[impl MultilinearExtension<E::Fr>],
+    points: &[impl AsRef<[E::Fr]>],
+    transcript: &mut impl Transcript,
+) -> (Vec<E::Fr>, BatchOpening<E::Fr, PCS>)
+where
+    E: Engine + MultiMillerLoop,
+    E::Fr: ExtensionField + PrimeField,
+    E::G1Affine: ExpSerde + Default + CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1>,
+    E::G2Affine: ExpSerde + Default + CurveAffine<ScalarExt = E::Fr, CurveExt = E::G2>,
+    PCS: PolynomialCommitmentScheme<E::Fr, Opening = HyperUniKZGOpening<E>>,
+{
+    let timer = Timer::new("batch_opening", true);
+    // generate evals for each polynomial at its corresponding point
+    let eval_timer = Timer::new("eval all polys", true);
+    let points = points.iter().map(|p| p.as_ref()).collect::<Vec<_>>();
+    let evals: Vec<E::Fr> = polys
+        .par_iter()
+        .zip_eq(points.par_iter())
+        .map(|(poly, point)| poly.evaluate(point))
+        .collect();
+    eval_timer.stop();
+
+    let merger_timer = Timer::new("merging points", true);
+    let (new_point, g_prime, proof) =
+        prover_merge_points::<E::G1Affine>(polys, &points, transcript);
+    merger_timer.stop();
+
+    let pcs_timer = Timer::new("kzg_open", true);
+    let (_g_prime_eval, g_prime_proof) =
+        coeff_form_uni_hyperkzg_open(proving_key, &g_prime.coeffs, &new_point, transcript);
+    pcs_timer.stop();
+
+    timer.stop();
+    (
+        evals,
+        BatchOpening {
+            sum_check_proof: proof,
+            g_prime_proof,
+        },
+    )
+}
+
+pub fn multiple_points_batch_verify_impl<E, PCS>(
+    verifying_key: &UniKZGVerifierParams<E>,
+    commitments: &[impl AsRef<UniKZGCommitment<E>>],
+    points: &[impl AsRef<[E::Fr]>],
+    values: &[E::Fr],
+    batch_opening: &BatchOpening<E::Fr, PCS>,
+    transcript: &mut impl Transcript,
+) -> bool
+where
+    E: Engine + MultiMillerLoop,
+    E::Fr: ExtensionField + PrimeField,
+    E::G1Affine: ExpSerde + Default + CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1>,
+    E::G2Affine: ExpSerde + Default + CurveAffine<ScalarExt = E::Fr, CurveExt = E::G2>,
+    PCS: PolynomialCommitmentScheme<E::Fr, Opening = HyperUniKZGOpening<E>>,
+{
+    let a2 = batch_opening.sum_check_proof.export_point_to_expander();
+
+    let commitments = commitments
+        .iter()
+        .map(|c| vec![c.as_ref().0])
+        .collect::<Vec<_>>();
+
+    let (tilde_g_eval, g_prime_commit) = verifier_merge_points::<E::G1Affine>(
+        &commitments,
+        points,
+        values,
+        &batch_opening.sum_check_proof,
+        transcript,
+    );
+
+    // verify commitment
+    coeff_form_uni_hyperkzg_verify(
+        verifying_key,
+        g_prime_commit[0],
+        a2.as_ref(),
+        tilde_g_eval,
+        &batch_opening.g_prime_proof,
+        transcript,
+    )
 }

--- a/poly_commit/src/kzg/uni_kzg/pcs_trait_impl.rs
+++ b/poly_commit/src/kzg/uni_kzg/pcs_trait_impl.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 
-use ::utils::timer::Timer;
 use arith::ExtensionField;
 use gkr_engine::{StructuredReferenceString, Transcript};
 use halo2curves::{
@@ -9,11 +8,8 @@ use halo2curves::{
     CurveAffine,
 };
 use polynomials::MultiLinearPoly;
-use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use serdes::ExpSerde;
 
-use crate::batching::prover_merge_points;
-use crate::batching::verifier_merge_points;
 use crate::{
     traits::{BatchOpening, BatchOpeningPCS},
     *,

--- a/poly_commit/src/kzg/uni_kzg/structs_kzg.rs
+++ b/poly_commit/src/kzg/uni_kzg/structs_kzg.rs
@@ -9,6 +9,15 @@ pub struct UniKZGCommitment<E: Engine>(pub E::G1Affine)
 where
     E::G1Affine: CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1>;
 
+impl<E: Engine> AsRef<UniKZGCommitment<E>> for UniKZGCommitment<E>
+where
+    E::G1Affine: CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1>,
+{
+    fn as_ref(&self) -> &UniKZGCommitment<E> {
+        self
+    }
+}
+
 // Derive macros does not work for associated types
 impl<E: Engine> ExpSerde for UniKZGCommitment<E>
 where

--- a/poly_commit/src/traits.rs
+++ b/poly_commit/src/traits.rs
@@ -72,9 +72,9 @@ where
 }
 
 /// Batch opening polynomial commitment scheme trait.
-/// This trait is implemented for homomorphic polynomial commitment schemes such as Hyrax and KZG
 pub trait BatchOpeningPCS<F: ExtensionField>: PolynomialCommitmentScheme<F> + Sized {
-    /// Open a set of polynomials at a single point.
+    /// This trait is implemented for homomorphic polynomial commitment schemes such as Hyrax and
+    /// KZG Open a set of polynomials at a single point.
     fn single_point_batch_open(
         params: &Self::Params,
         proving_key: &<Self::SRS as StructuredReferenceString>::PKey,

--- a/poly_commit/tests/common.rs
+++ b/poly_commit/tests/common.rs
@@ -275,6 +275,7 @@ where
     C: FieldEngine,
     T: Transcript,
     P: ExpanderPCS<C, C::SimdCircuitField, Params = usize>,
+    P::Commitment: AsRef<P::Commitment>,
 {
     let mut rng = test_rng();
     let mpi_config = MPIConfig::prover_new(None, None);


### PR DESCRIPTION
1. Replace `MultiLinearPoly` with `impl MultiLinearExtension`. 
2. Replace `&[Commitment]`, with `&[impl AsRef<Commitment>]`.

I'm not so sure about the second one though. It requires `Commitment` to implement `AsRef<Commitment>`, which, surprisely, is not implemented for all types.