### PR TITLE
Allow variable-length polys in SumOfProduct Poly and PCS Claims Merging

### DIFF
--- a/arith/polynomials/src/sum_of_products.rs
+++ b/arith/polynomials/src/sum_of_products.rs
@@ -23,24 +23,16 @@ impl<F: Field> SumOfProductsPoly<F> {
     /// Get the number of variables in the polynomial
     #[inline]
     pub fn num_vars(&self) -> usize {
-        if self.f_and_g_pairs.is_empty() {
-            0
-        } else {
-            self.f_and_g_pairs[0].0.num_vars()
-        }
+        self.f_and_g_pairs
+            .iter()
+            .map(|(f, _)| f.num_vars())
+            .max()
+            .unwrap_or(0)
     }
 
     #[inline]
     pub fn add_pair(&mut self, poly0: MultiLinearPoly<F>, poly1: MultiLinearPoly<F>) {
         assert_eq!(poly0.num_vars(), poly1.num_vars());
-        if !self.f_and_g_pairs.is_empty() {
-            // Ensure new pair's num_vars matches existing pairs.
-            assert_eq!(
-                self.num_vars(),
-                poly0.num_vars(),
-                "All polynomial pairs must have the same number of variables"
-            );
-        }
         self.f_and_g_pairs.push((poly0, poly1));
     }
 

--- a/poly_commit/src/batching.rs
+++ b/poly_commit/src/batching.rs
@@ -33,11 +33,7 @@ where
     C::Scalar: ExtensionField + PrimeField,
     C::ScalarExt: ExtensionField + PrimeField,
 {
-    let num_vars = polys
-        .iter()
-        .map(|p| p.hypercube_basis_ref().len())
-        .max()
-        .unwrap_or(0);
+    let num_vars = polys.iter().map(|p| p.num_vars()).max().unwrap_or(0);
     let k = polys.len();
     let ell = log2(k) as usize;
 
@@ -205,6 +201,7 @@ fn transpose<C: CurveAffine>(m: &[&[C]]) -> Vec<Vec<C>> {
 
 #[inline]
 #[allow(clippy::type_complexity)]
+#[allow(unused)]
 fn pad_polynomials_and_points<C>(
     polys: &[impl MultilinearExtension<C::Scalar>],
     points: &[impl AsRef<[C::Scalar]>],

--- a/poly_commit/tests/common.rs
+++ b/poly_commit/tests/common.rs
@@ -309,7 +309,7 @@ where
                 .map(|i| ExpanderSingleVarChallenge::<C> {
                     r_mpi: Vec::new(),
                     r_simd: Vec::new(),
-                    rz: (0.. polys[i].num_vars())
+                    rz: (0..polys[i].num_vars())
                         .map(|_| C::ChallengeField::random_unsafe(&mut rng))
                         .collect(),
                 })

--- a/poly_commit/tests/test_hyrax.rs
+++ b/poly_commit/tests/test_hyrax.rs
@@ -89,5 +89,5 @@ fn test_hyrax_batch_open() {
         BN254Config,
         BytesHashTranscript<Keccak256hasher>,
         HyraxPCS<G1Affine>,
-    >();
+    >(false);
 }

--- a/poly_commit/tests/test_uni_kzg.rs
+++ b/poly_commit/tests/test_uni_kzg.rs
@@ -97,5 +97,5 @@ fn test_uni_kzg_batch_open() {
         BN254Config,
         BytesHashTranscript<Keccak256hasher>,
         HyperUniKZGPCS<Bn256>,
-    >();
+    >(true);
 }

--- a/sumcheck/src/sumcheck_generic.rs
+++ b/sumcheck/src/sumcheck_generic.rs
@@ -50,6 +50,10 @@ pub struct IOPProverState<F: Field> {
     /// list of MLE poly
     // todo: change this to reference
     pub mle_list: SumOfProductsPoly<F>,
+
+    pub init_sum_of_vals: Vec<F>,
+
+    pub eq_prefix: Vec<F>,
 }
 
 /// Prover State of a PolyIOP

--- a/sumcheck/src/sumcheck_generic/prover.rs
+++ b/sumcheck/src/sumcheck_generic/prover.rs
@@ -175,7 +175,7 @@ impl<F: Field> IOPProverState<F> {
             .for_each(|((f, g), eq_prefix)| {
                 if let Some(_sub_idx) =
                     Self::get_sub_idx(self.init_num_vars, self.round, f.num_vars())
-                {                    
+                {
                     // fix the top variable for each polynomial pair
                     f.fix_top_variable(*challenge);
                     g.fix_top_variable(*challenge);

--- a/sumcheck/src/sumcheck_generic/prover.rs
+++ b/sumcheck/src/sumcheck_generic/prover.rs
@@ -1,6 +1,12 @@
 use arith::Field;
-use polynomials::SumOfProductsPoly;
-use rayon::iter::{IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator};
+use polynomials::{MultiLinearPoly, MultilinearExtension, SumOfProductsPoly};
+use rayon::{
+    iter::{
+        IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator,
+        ParallelIterator,
+    },
+    vec,
+};
 
 use super::{IOPProverMessage, IOPProverState};
 
@@ -8,11 +14,24 @@ impl<F: Field> IOPProverState<F> {
     /// Initialize the prover state to argue for the sum of the input polynomial
     /// over {0,1}^`num_vars`.
     pub fn prover_init(polynomials: &SumOfProductsPoly<F>) -> Self {
+        let num_vars = polynomials.num_vars();
         Self {
-            challenges: Vec::with_capacity(polynomials.num_vars()),
+            challenges: Vec::with_capacity(num_vars),
             round: 0,
-            init_num_vars: polynomials.num_vars(),
+            init_num_vars: num_vars,
             mle_list: polynomials.clone(),
+            init_sum_of_vals: polynomials
+                .f_and_g_pairs
+                .iter()
+                .map(|(f, g)| {
+                    f.coeffs
+                        .iter()
+                        .zip(g.coeffs.iter())
+                        .map(|(&f, &g)| f * g)
+                        .sum::<F>()
+                })
+                .collect(),
+            eq_prefix: vec![F::one(); num_vars],
         }
     }
 
@@ -45,21 +64,13 @@ impl<F: Field> IOPProverState<F> {
 
             let r = self.challenges[self.round - 1];
 
-            self.mle_list
-                .f_and_g_pairs
-                .par_iter_mut()
-                .for_each(|(f, g)| {
-                    // fix the top variable of f and g to r
-                    f.fix_top_variable(r);
-                    g.fix_top_variable(r);
-                });
+            self.fix_top_variable_for_poly_pairs(&r);
         } else if self.round > 0 {
             panic!("verifier message is empty")
         }
 
         self.round += 1;
 
-        let len = 1 << (self.mle_list.num_vars() - 1);
         let mut h_0 = F::zero();
         let mut h_1 = F::zero();
         let mut h_2 = F::zero();
@@ -91,39 +102,59 @@ impl<F: Field> IOPProverState<F> {
         self.mle_list
             .f_and_g_pairs
             .par_iter()
-            .map(|(f, g)| {
+            .enumerate()
+            .map(|(i, (f, g))| {
                 // evaluate the polynomial at 0, 1 and 2
                 // and obtain f(0)g(0) and f(1)g(1) and f(2)g(2)
 
-                let f_coeffs = f.coeffs.as_slice();
-                let g_coeffs = g.coeffs.as_slice();
+                if let Some(sub_idx) = Self::get_sub_idx(
+                    self.init_num_vars,
+                    self.round,
+                    f.num_vars(),
+                ) {
+                    let len = 1 << (f.num_vars() - sub_idx - 1);
+                    let f_coeffs = f.coeffs.as_slice();
+                    let g_coeffs = g.coeffs.as_slice();
 
-                let h_0_local = f_coeffs[..len]
-                    .iter()
-                    .zip(g_coeffs[..len].iter())
-                    .map(|(&f, &g)| f * g)
-                    .sum::<F>();
+                    let h_0_local = f_coeffs[..len]
+                        .iter()
+                        .zip(g_coeffs[..len].iter())
+                        .map(|(&f, &g)| f * g)
+                        .sum::<F>();
 
-                let h_1_local = f_coeffs[len..]
-                    .iter()
-                    .zip(g_coeffs[len..].iter())
-                    .map(|(&f, &g)| f * g)
-                    .sum::<F>();
+                    let h_1_local = f_coeffs[len..]
+                        .iter()
+                        .zip(g_coeffs[len..].iter())
+                        .map(|(&f, &g)| f * g)
+                        .sum::<F>();
 
-                let h_2_local = f_coeffs[..len]
-                    .iter()
-                    .zip(f_coeffs[len..].iter())
-                    .map(|(a, b)| -*a + b.double())
-                    .zip(
-                        g_coeffs[..len]
-                            .iter()
-                            .zip(g_coeffs[len..].iter())
-                            .map(|(a, b)| -*a + b.double()),
+                    let h_2_local = f_coeffs[..len]
+                        .iter()
+                        .zip(f_coeffs[len..].iter())
+                        .map(|(a, b)| -*a + b.double())
+                        .zip(
+                            g_coeffs[..len]
+                                .iter()
+                                .zip(g_coeffs[len..].iter())
+                                .map(|(a, b)| -*a + b.double()),
+                        )
+                        .map(|(a, b)| a * b)
+                        .sum::<F>();
+                    
+                    let eq_prefix_i = self.eq_prefix[i];
+                    (
+                        h_0_local * eq_prefix_i,
+                        h_1_local * eq_prefix_i,
+                        h_2_local * eq_prefix_i,
                     )
-                    .map(|(a, b)| a * b)
-                    .sum::<F>();
-
-                (h_0_local, h_1_local, h_2_local)
+                } else {
+                    let h = self.eq_prefix[i] * self.init_sum_of_vals[i];
+                    (
+                        h,
+                        F::zero(),
+                        -h,
+                    )
+                }
             })
             .collect::<Vec<_>>()
             .iter()
@@ -136,5 +167,31 @@ impl<F: Field> IOPProverState<F> {
         IOPProverMessage {
             evaluations: vec![h_0, h_1, h_2],
         }
+    }
+
+    fn get_sub_idx(init_num_vars: usize, round: usize, local_num_vars: usize) -> Option<usize> {
+        if init_num_vars - round > local_num_vars {
+            None
+        } else {
+            Some(local_num_vars - (init_num_vars - round))
+        }
+    }
+
+    fn fix_top_variable_for_poly_pairs(&mut self, challenge: &F) {
+        self.mle_list
+            .f_and_g_pairs
+            .par_iter_mut()
+            .zip(self.eq_prefix.par_iter_mut())
+            .for_each(|((f, g), eq_prefix)| {
+                if let Some(_sub_idx) =
+                    Self::get_sub_idx(self.init_num_vars, self.round, f.num_vars())
+                {
+                    *eq_prefix *= F::one() - *challenge; // eq(challenge, 0)
+                } else {
+                    // fix the top variable for each polynomial pair
+                    f.fix_top_variable(*challenge);
+                    g.fix_top_variable(*challenge);
+                }
+            });
     }
 }

--- a/sumcheck/src/sumcheck_generic/prover.rs
+++ b/sumcheck/src/sumcheck_generic/prover.rs
@@ -1,11 +1,7 @@
 use arith::Field;
-use polynomials::{MultiLinearPoly, MultilinearExtension, SumOfProductsPoly};
-use rayon::{
-    iter::{
-        IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator,
-        ParallelIterator,
-    },
-    vec,
+use polynomials::{MultilinearExtension, SumOfProductsPoly};
+use rayon::iter::{
+    IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
 };
 
 use super::{IOPProverMessage, IOPProverState};
@@ -107,11 +103,9 @@ impl<F: Field> IOPProverState<F> {
                 // evaluate the polynomial at 0, 1 and 2
                 // and obtain f(0)g(0) and f(1)g(1) and f(2)g(2)
 
-                if let Some(sub_idx) = Self::get_sub_idx(
-                    self.init_num_vars,
-                    self.round,
-                    f.num_vars(),
-                ) {
+                if let Some(sub_idx) =
+                    Self::get_sub_idx(self.init_num_vars, self.round, f.num_vars())
+                {
                     let len = 1 << (f.num_vars() - sub_idx - 1);
                     let f_coeffs = f.coeffs.as_slice();
                     let g_coeffs = g.coeffs.as_slice();
@@ -140,7 +134,7 @@ impl<F: Field> IOPProverState<F> {
                         )
                         .map(|(a, b)| a * b)
                         .sum::<F>();
-                    
+
                     let eq_prefix_i = self.eq_prefix[i];
                     (
                         h_0_local * eq_prefix_i,
@@ -149,11 +143,7 @@ impl<F: Field> IOPProverState<F> {
                     )
                 } else {
                     let h = self.eq_prefix[i] * self.init_sum_of_vals[i];
-                    (
-                        h,
-                        F::zero(),
-                        -h,
-                    )
+                    (h, F::zero(), -h)
                 }
             })
             .collect::<Vec<_>>()

--- a/sumcheck/src/sumcheck_generic/tests.rs
+++ b/sumcheck/src/sumcheck_generic/tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use arith::Fr;
 use ark_std::{rand::thread_rng, test_rng};
 use gkr_hashers::{Keccak256hasher, SHA256hasher};
-use polynomials::MultiLinearPoly;
+use polynomials::{MultiLinearPoly, MutableMultilinearExtension};
 use transcript::BytesHashTranscript;
 
 #[test]
@@ -111,8 +111,8 @@ fn test_sumcheck_generic_padding_helper<F: Field, T: Transcript>() {
         f_and_g_pairs: (0..num_polys)
             .map(|i| {
                 let num_vars = i % (max_num_vars + 1);
-                let poly0 = MultiLinearPoly::random(num_vars, &mut rng);
-                let poly1 = MultiLinearPoly::random(num_vars, &mut rng);
+                let poly0 = MultiLinearPoly::<F>::random(num_vars, &mut rng);
+                let poly1 = MultiLinearPoly::<F>::random(num_vars, &mut rng);
                 (poly0, poly1)
             })
             .collect(),
@@ -126,22 +126,11 @@ fn test_sumcheck_generic_padding_helper<F: Field, T: Transcript>() {
             .f_and_g_pairs
             .iter()
             .map(|(f, g)| {
-                (
-                    MultiLinearPoly {
-                        coeffs: {
-                            let mut coeffs = f.coeffs.clone();
-                            coeffs.resize(1 << max_num_vars, F::zero());
-                            coeffs
-                        },
-                    },
-                    MultiLinearPoly {
-                        coeffs: {
-                            let mut coeffs = g.coeffs.clone();
-                            coeffs.resize(1 << max_num_vars, F::zero());
-                            coeffs
-                        },
-                    },
-                )
+                let mut f_padded = f.clone();
+                f_padded.lift_to_n_vars(max_num_vars);
+                let mut g_padded = g.clone();
+                g_padded.lift_to_n_vars(max_num_vars);
+                (f_padded, g_padded)
             })
             .collect(),
     };

--- a/sumcheck/src/sumcheck_generic/tests.rs
+++ b/sumcheck/src/sumcheck_generic/tests.rs
@@ -150,8 +150,12 @@ fn test_sumcheck_generic_padding_helper<F: Field, T: Transcript>() {
 
     assert_eq!(proof, proof_with_padded_mle_list);
 
-    let (verified, subclaim) =
-        SumCheck::verify(claimed_sum, &proof_with_padded_mle_list, max_num_vars, &mut T::new());
+    let (verified, subclaim) = SumCheck::verify(
+        claimed_sum,
+        &proof_with_padded_mle_list,
+        max_num_vars,
+        &mut T::new(),
+    );
     assert!(verified, "sumcheck verification failed");
     let evals = mle_list.evaluate(&subclaim.point);
     assert!(evals == subclaim.expected_evaluation, "wrong subclaim");

--- a/sumcheck/src/sumcheck_generic/tests.rs
+++ b/sumcheck/src/sumcheck_generic/tests.rs
@@ -124,18 +124,24 @@ fn test_sumcheck_generic_padding_helper<F: Field, T: Transcript>() {
         f_and_g_pairs: mle_list
             .f_and_g_pairs
             .iter()
-            .map(|(f, g)| (
-                MultiLinearPoly { coeffs: {
-                    let mut coeffs = f.coeffs.clone();
-                    coeffs.resize(1 << max_num_vars, F::zero());
-                    coeffs
-                } },
-                MultiLinearPoly { coeffs: {
-                    let mut coeffs = g.coeffs.clone();
-                    coeffs.resize(1 << max_num_vars, F::zero());
-                    coeffs
-                } },
-            ))
+            .map(|(f, g)| {
+                (
+                    MultiLinearPoly {
+                        coeffs: {
+                            let mut coeffs = f.coeffs.clone();
+                            coeffs.resize(1 << max_num_vars, F::zero());
+                            coeffs
+                        },
+                    },
+                    MultiLinearPoly {
+                        coeffs: {
+                            let mut coeffs = g.coeffs.clone();
+                            coeffs.resize(1 << max_num_vars, F::zero());
+                            coeffs
+                        },
+                    },
+                )
+            })
             .collect(),
     };
 


### PR DESCRIPTION
In sumcheck for the `SumOfProduct` Poly, we required all the polynomials to have the same length. In some cases where there were smaller polynomials, we padded them to max length, and then commit, merge, and open. This worked, but were not very efficient. This PR made the following changes:

1. Allow variable-length polys in `SumOfProduct` poly without padding overhead.
2. Adapt the sumcheck protocol to the new poly, increasing efficiency.
3. In merging multiple PCS claims and challenges, remove the padding overhead, the overall cost is linear to the total size now.
