### PR TITLE
[BUG] Fix HyperKZG verify ignoring pairing check result

### DIFF
--- a/poly_commit/src/kzg/uni_kzg/hyper_kzg.rs
+++ b/poly_commit/src/kzg/uni_kzg/hyper_kzg.rs
@@ -252,9 +252,7 @@ where
         tau,
         lagrange_eval,
         opening.quotient_delta_x_commitment,
-    );
-
-    true
+    )
 }
 
 pub fn multiple_points_batch_open_impl<E, PCS>(


### PR DESCRIPTION
`coeff_form_uni_hyperkzg_verify` was discarding the result of the pairing check and returning `true` unconditionally.

```rust
coeff_form_uni_kzg_verify(...);  // result discarded
true                              // always passed
```

This meant any proof would pass verification.

Fixed by returning the actual result. Added regression test that corrupts a proof and verifies it gets rejected.