### PR TITLE
Reduce memory in SumCheck::prove via move semantics

### DIFF
--- a/poly_commit/src/batching.rs
+++ b/poly_commit/src/batching.rs
@@ -80,7 +80,7 @@ where
     for (tilde_g, tilde_eq) in tilde_gs.iter().zip(tilde_eqs.into_iter()) {
         sumcheck_poly.add_pair(tilde_g.clone(), tilde_eq);
     }
-    let proof = SumCheck::<C::Scalar>::prove(&sumcheck_poly, transcript);
+    let proof = SumCheck::<C::Scalar>::prove(sumcheck_poly, transcript);
     timer.stop();
 
     let a2 = proof.export_point_to_expander();

--- a/sumcheck/src/sumcheck_generic.rs
+++ b/sumcheck/src/sumcheck_generic.rs
@@ -93,13 +93,14 @@ impl<F: Field> SumCheck<F> {
     /// Generate proof of the sum of polynomial over {0,1}^`num_vars`
     ///
     /// The polynomial is represented in the form of a VirtualPolynomial.
+    /// Takes ownership of poly_list to avoid cloning internally.
     pub fn prove(
-        poly_list: &SumOfProductsPoly<F>,
+        poly_list: SumOfProductsPoly<F>,
         transcript: &mut impl Transcript,
     ) -> IOPProof<F> {
         let num_vars = poly_list.num_vars();
 
-        let mut prover_state = IOPProverState::prover_init(poly_list);
+        let mut prover_state = IOPProverState::prover_init_owned(poly_list);
         let mut challenge = None;
         let mut prover_msgs = Vec::with_capacity(num_vars);
         for _ in 0..num_vars {

--- a/sumcheck/src/sumcheck_generic/tests.rs
+++ b/sumcheck/src/sumcheck_generic/tests.rs
@@ -89,7 +89,7 @@ fn test_sumcheck_e2e() {
 
             // prover
             let mut transcript = BytesHashTranscript::<Keccak256hasher>::new();
-            let proof = SumCheck::<Fr>::prove(&mle_list, &mut transcript);
+            let proof = SumCheck::<Fr>::prove(mle_list.clone(), &mut transcript);
 
             // verifier
             let mut transcript = BytesHashTranscript::<Keccak256hasher>::new();
@@ -119,7 +119,7 @@ fn test_sumcheck_generic_padding_helper<F: Field, T: Transcript>() {
     };
     let claimed_sum = mle_list.sum();
 
-    let proof = SumCheck::prove(&mle_list, &mut T::new());
+    let proof = SumCheck::prove(mle_list.clone(), &mut T::new());
 
     let padded_mle_list = SumOfProductsPoly {
         f_and_g_pairs: mle_list
@@ -135,7 +135,7 @@ fn test_sumcheck_generic_padding_helper<F: Field, T: Transcript>() {
             .collect(),
     };
 
-    let proof_with_padded_mle_list = SumCheck::prove(&padded_mle_list, &mut T::new());
+    let proof_with_padded_mle_list = SumCheck::prove(padded_mle_list, &mut T::new());
 
     assert_eq!(proof, proof_with_padded_mle_list);
 


### PR DESCRIPTION
## Summary
- Add `prover_init_owned()` to `IOPProverState` that takes `SumOfProductsPoly` by value, eliminating the `clone()` in `prover_init()`
- Change `SumCheck::prove()` signature from `&SumOfProductsPoly<F>` to `SumOfProductsPoly<F>` (ownership)
- Update `prover_merge_points` in batching to pass `sumcheck_poly` by move
- The original `prover_init()` (borrow + clone) is preserved for callers that need it

## Motivation
During batched polynomial commitment opening, `SumCheck::prove` internally clones the entire polynomial list via `prover_init`. For large proving workloads (e.g., ZKML with many kernels), this clone can consume significant memory. By accepting ownership, we eliminate one full copy of the polynomial data.


🤖 Generated with [Claude Code](https://claude.com/claude-code)