### PR TITLE
Add low-memory mode for batch polynomial opening

### DIFF
--- a/gkr/Cargo.toml
+++ b/gkr/Cargo.toml
@@ -41,6 +41,7 @@ default = []
 grinding = [ ]
 recursion = [ "transcript/recursion" ]
 profile = [ "utils/profile", "sumcheck/profile" ]
+low-memory = [ "poly_commit/low-memory" ]
 
 [[bench]]
 name = "gkr-hashes"

--- a/poly_commit/Cargo.toml
+++ b/poly_commit/Cargo.toml
@@ -51,3 +51,4 @@ harness = false
 default = [ ]
 profile = [ "utils/profile" ]
 cuda_msm = [ "msm_cuda" ]
+low-memory = [ ]

--- a/poly_commit/src/batching.rs
+++ b/poly_commit/src/batching.rs
@@ -18,11 +18,16 @@ use utils::timer::Timer;
 /// - the new point for evaluation
 /// - the new polynomial that is merged via sumcheck
 /// - the proof of the sumcheck
+///
+/// When `low_memory` is true, tilde_gs are moved (not cloned) into sumcheck and
+/// recomputed afterwards for g_prime construction. This reduces peak memory at
+/// the cost of redundant computation.
 #[allow(clippy::type_complexity)]
 pub fn prover_merge_points<C>(
     polys: &[impl MultilinearExtension<C::Scalar>],
     points: &[impl AsRef<[C::Scalar]>],
     transcript: &mut impl Transcript,
+    low_memory: bool,
 ) -> (
     Vec<C::Scalar>,
     MultiLinearPoly<C::Scalar>,
@@ -46,20 +51,7 @@ where
     // \tilde g_i(b) = eq(t, i) * f_i(b)
     let timer = Timer::new("Building tilde g_i(b)", true);
 
-    let tilde_gs = polys
-        .par_iter()
-        .enumerate()
-        .map(|(index, f_i)| {
-            let mut tilde_g_eval = vec![C::Scalar::zero(); 1 << f_i.num_vars()];
-            for (j, &f_i_eval) in f_i.hypercube_basis_ref().iter().enumerate() {
-                tilde_g_eval[j] = f_i_eval * eq_t_i[index];
-            }
-
-            MultiLinearPoly {
-                coeffs: tilde_g_eval,
-            }
-        })
-        .collect::<Vec<_>>();
+    let tilde_gs = build_tilde_gs(polys, &eq_t_i);
     timer.stop();
 
     // built the virtual polynomial for SumCheck
@@ -77,8 +69,15 @@ where
 
     let timer = Timer::new("Sumcheck merging points", true);
     let mut sumcheck_poly = SumOfProductsPoly::new();
-    for (tilde_g, tilde_eq) in tilde_gs.iter().zip(tilde_eqs.into_iter()) {
-        sumcheck_poly.add_pair(tilde_g.clone(), tilde_eq);
+    if low_memory {
+        // Move tilde_gs into sumcheck_poly to avoid holding two copies simultaneously
+        for (tilde_g, tilde_eq) in tilde_gs.into_iter().zip(tilde_eqs.into_iter()) {
+            sumcheck_poly.add_pair(tilde_g, tilde_eq);
+        }
+    } else {
+        for (tilde_g, tilde_eq) in tilde_gs.iter().zip(tilde_eqs.into_iter()) {
+            sumcheck_poly.add_pair(tilde_g.clone(), tilde_eq);
+        }
     }
     let proof = SumCheck::<C::Scalar>::prove(sumcheck_poly, transcript);
     timer.stop();
@@ -99,7 +98,15 @@ where
         })
         .collect::<Vec<_>>();
 
-    for (tilde_g, eq_i_a2) in tilde_gs.iter().zip(eq_i_a2_polys.iter()) {
+    // In low_memory mode, tilde_gs were moved into sumcheck_poly and consumed.
+    // Recompute them for g_prime construction.
+    let tilde_gs_for_gprime = if low_memory {
+        build_tilde_gs(polys, &eq_t_i)
+    } else {
+        tilde_gs
+    };
+
+    for (tilde_g, eq_i_a2) in tilde_gs_for_gprime.iter().zip(eq_i_a2_polys.iter()) {
         for (j, &tilde_g_eval) in tilde_g.coeffs.iter().enumerate() {
             g_prime_evals[j] += tilde_g_eval * eq_i_a2;
         }
@@ -109,6 +116,26 @@ where
     };
     timer.stop();
     (a2, g_prime, proof)
+}
+
+/// Build tilde_gs: \tilde g_i(b) = eq(t, i) * f_i(b)
+fn build_tilde_gs<S: ExtensionField + PrimeField>(
+    polys: &[impl MultilinearExtension<S>],
+    eq_t_i: &[S],
+) -> Vec<MultiLinearPoly<S>> {
+    polys
+        .par_iter()
+        .enumerate()
+        .map(|(index, f_i)| {
+            let mut tilde_g_eval = vec![S::zero(); 1 << f_i.num_vars()];
+            for (j, &f_i_eval) in f_i.hypercube_basis_ref().iter().enumerate() {
+                tilde_g_eval[j] = f_i_eval * eq_t_i[index];
+            }
+            MultiLinearPoly {
+                coeffs: tilde_g_eval,
+            }
+        })
+        .collect()
 }
 
 pub fn verifier_merge_points<C>(

--- a/poly_commit/src/hyrax/hyrax_impl.rs
+++ b/poly_commit/src/hyrax/hyrax_impl.rs
@@ -358,7 +358,7 @@ where
     eval_timer.stop();
 
     let merger_timer = Timer::new("merging points", true);
-    let (new_point, g_prime, proof) = prover_merge_points::<C>(polys, points, transcript);
+    let (new_point, g_prime, proof) = prover_merge_points::<C>(polys, points, transcript, cfg!(feature = "low-memory"));
     merger_timer.stop();
 
     // open g'(X) at point (a2)

--- a/poly_commit/src/kzg/uni_kzg/hyper_kzg.rs
+++ b/poly_commit/src/kzg/uni_kzg/hyper_kzg.rs
@@ -289,7 +289,7 @@ where
 
     let merger_timer = Timer::new("merging points", true);
     let (new_point, g_prime, proof) =
-        prover_merge_points::<E::G1Affine>(polys, &points, transcript);
+        prover_merge_points::<E::G1Affine>(polys, &points, transcript, cfg!(feature = "low-memory"));
     merger_timer.stop();
 
     let pcs_timer = Timer::new("kzg_open", true);


### PR DESCRIPTION
## Summary
- Add `low-memory` Cargo feature to `poly_commit` crate
- When enabled, `prover_merge_points` moves `tilde_gs` into sumcheck (zero clone) and recomputes them for g_prime, reducing peak memory by eliminating one full copy of the polynomial data
- When disabled (default), behavior is identical to before — full backward compatibility
- Extract `build_tilde_gs` helper to avoid code duplication between the two paths

## Design
The optimization trades compute time for memory:
- **Default** (`low-memory` off): clone tilde_gs into sumcheck_poly, keep original for g_prime — same as current behavior
- **Low-memory** (`low-memory` on): move tilde_gs into sumcheck_poly, recompute from polys + eq_t_i for g_prime — peak memory reduced by ~size(tilde_gs)

Usage:
```toml
# In downstream Cargo.toml
poly_commit = { path = "...", features = ["low-memory"] }
```

The `low_memory` parameter is also exposed as a `bool` on `prover_merge_points` for callers that want runtime control.

## Test plan
- [ ] `cargo test -p poly_commit` (default, no feature)
- [ ] `cargo test -p poly_commit --features low-memory`
- [ ] Proof output should be identical in both modes (deterministic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)