### PR TITLE
fix(serdes): decode usize as u64 on 32-bit targets (wasm32 verifier)

### DIFF
--- a/serdes/src/serdes.rs
+++ b/serdes/src/serdes.rs
@@ -32,7 +32,20 @@ impl ExpSerde for () {
 }
 
 exp_serde_for_number!(u64, 8);
-exp_serde_for_number!(usize, 8);
+// `usize` serializes as a fixed-width u64 so proofs produced on 64-bit
+// hosts (prover) decode on 32-bit targets too (wasm32-unknown-unknown
+// consumers — mobile, browser, any WASM verifier). The generic
+// `exp_serde_for_number!(usize, 8)` macro hits an 8-vs-4 byte mismatch
+// on 32-bit targets where `usize::from_le_bytes` takes `[u8; 4]`.
+impl ExpSerde for usize {
+    fn serialize_into<W: Write>(&self, writer: W) -> SerdeResult<()> {
+        (*self as u64).serialize_into(writer)
+    }
+    fn deserialize_from<R: Read>(mut reader: R) -> SerdeResult<Self> {
+        let v = u64::deserialize_from(&mut reader)?;
+        usize::try_from(v).map_err(|_| SerdeError::DeserializeError)
+    }
+}
 exp_serde_for_number!(u8, 1);
 exp_serde_for_number!(f64, 8);
 exp_serde_for_number!(u128, 16);


### PR DESCRIPTION
## Problem

`exp_serde_for_number!(usize, 8)` expands to a `usize::from_le_bytes([u8; 8])` call. On 32-bit targets (`wasm32-unknown-unknown`, `wasm32-wasi`) `usize::from_le_bytes` takes `[u8; 4]`, so the macro fails to compile.

## Fix

Replace the macro call for `usize` with a hand-written `ExpSerde` impl that:

- **Serializes** as a fixed-width 8 bytes (matches current 64-bit behavior — wire format unchanged).
- **Deserializes** by reading 8 bytes into a `u64`, then `try_from`-ing to `usize`. Values above `usize::MAX` on 32-bit (4 GiB) return `SerdeError::DeserializeError`.

## Why

Proofs are produced on 64-bit hosts; the wire format already stores `usize` as 8 bytes. This is purely a 32-bit-decode fix — no change to what 64-bit consumers see.

Motivation: unblocks browser / mobile WASM verifier builds that need to deserialize `Circuit<C>` and `Proof` on `wasm32-unknown-unknown`.

## Scope

- 18 lines in `serdes/src/serdes.rs`.
- No wire-format change.
- No test fixtures need regenerating.